### PR TITLE
Add `explicit_size` option to `RenderOptions`

### DIFF
--- a/examples/css_vars.rs
+++ b/examples/css_vars.rs
@@ -12,7 +12,10 @@ text "Red and Blue" at (0.5, -0.5) color green
     let program = pikru::parse::parse(source).expect("parse failed");
 
     // Render with CSS variables
-    let options = RenderOptions { css_variables: true };
+    let options = RenderOptions {
+        css_variables: true,
+        ..Default::default()
+    };
     let svg = render_with_options(&program, &options).expect("render failed");
 
     println!("{}", svg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,6 +656,38 @@ mod tests {
     }
 
     #[test]
+    fn render_explicit_size() {
+        use crate::render::{render_with_options, RenderOptions};
+
+        let input = r#"box "Hello""#;
+        let program = crate::parse::parse(input).expect("parse failed");
+
+        // Render without explicit_size - should not have width/height attributes
+        let svg_default = render_with_options(&program, &RenderOptions::default())
+            .expect("render failed");
+        assert!(
+            !svg_default.contains("width="),
+            "Default render should not have width attribute"
+        );
+
+        // Render with explicit_size - should have width/height attributes
+        let options = RenderOptions {
+            explicit_size: true,
+            ..Default::default()
+        };
+        let svg_explicit = render_with_options(&program, &options).expect("render failed");
+        assert!(
+            svg_explicit.contains("width=\""),
+            "explicit_size should add width attribute: {}",
+            svg_explicit
+        );
+        assert!(
+            svg_explicit.contains("height=\""),
+            "explicit_size should add height attribute"
+        );
+    }
+
+    #[test]
     fn render_all_pikchr_files() {
         // Files that are intentionally testing error handling
         let error_test_files = ["test60.pikchr", "test61.pikchr", "test62.pikchr"];

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -39,6 +39,7 @@ pub struct RenderOptions {
     /// Add explicit `width` and `height` attributes to the SVG element.
     /// When enabled, always adds `width` and `height` attributes to the SVG.
     /// This prevents inline SVGs from scaling up to fill their container.
+    /// The dimensions are computed using ceiling to avoid clipping.
     pub explicit_size: bool,
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -36,6 +36,10 @@ pub struct RenderOptions {
     /// Emit CSS variables for colors instead of direct color values.
     /// When enabled, generates a `<style>` block with all colors defined using `light-dark()`.
     pub css_variables: bool,
+    /// Add explicit `width` and `height` attributes to the SVG element.
+    /// When enabled, always adds `width` and `height` attributes to the SVG.
+    /// This prevents inline SVGs from scaling up to fill their container.
+    pub explicit_size: bool,
 }
 
 // TODO: Move these to appropriate submodules

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -336,7 +336,8 @@ pub fn generate_svg(
     // C pikchr: when scale != 1.0, display width = viewBox width * scale
     // cref: pik_render (pikchr.c:4626-4633) - C rounds viewbox to int first, then scales and rounds again
     // This matches the two-step rounding: wSVG = pik_round(rScale*w), then wSVG = pik_round(wSVG*pikScale)
-    let is_scaled = !(0.99..=1.01).contains(&scale);
+    // Also add explicit size when the option is enabled (prevents inline SVGs from scaling)
+    let is_scaled = !(0.99..=1.01).contains(&scale) || options.explicit_size;
     if is_scaled {
         let viewbox_width_int = viewbox_width as i32;
         let viewbox_height_int = viewbox_height as i32;

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -333,18 +333,27 @@ pub fn generate_svg(
         children: Vec::new(),
     };
 
-    // C pikchr: when scale != 1.0, display width = viewBox width * scale
-    // cref: pik_render (pikchr.c:4626-4633) - C rounds viewbox to int first, then scales and rounds again
-    // This matches the two-step rounding: wSVG = pik_round(rScale*w), then wSVG = pik_round(wSVG*pikScale)
-    // Also add explicit size when the option is enabled (prevents inline SVGs from scaling)
-    let is_scaled = !(0.99..=1.01).contains(&scale) || options.explicit_size;
-    if is_scaled {
-        let viewbox_width_int = viewbox_width as i32;
-        let viewbox_height_int = viewbox_height as i32;
-        let display_width = ((viewbox_width_int as f64) * scale) as i32;
-        let display_height = ((viewbox_height_int as f64) * scale) as i32;
-        svg.width = Some(display_width.to_string());
-        svg.height = Some(display_height.to_string());
+    'set_width_height: {
+        // C pikchr: when scale != 1.0, display width = viewBox width * scale
+        // cref: pik_render (pikchr.c:4626-4633) - C rounds viewbox to int first, then scales and rounds again
+        // This matches the two-step rounding: wSVG = pik_round(rScale*w), then wSVG = pik_round(wSVG*pikScale)
+        let is_scaled = !(0.99..=1.01).contains(&scale);
+        let (width, height) = if is_scaled {
+            let viewbox_width_int = viewbox_width as i32;
+            let viewbox_height_int = viewbox_height as i32;
+            let display_width = ((viewbox_width_int as f64) * scale) as i32;
+            let display_height = ((viewbox_height_int as f64) * scale) as i32;
+            (display_width, display_height)
+        } else if options.explicit_size {
+            // Use ceiling to avoid clipping: flooring could result in a pixel area slightly
+            // smaller than the content, which could clip edges (especially thin strokes or
+            // elements that touch the boundaries).
+            (viewbox_width.ceil() as i32, viewbox_height.ceil() as i32)
+        } else {
+            break 'set_width_height;
+        };
+        svg.width = Some(width.to_string());
+        svg.height = Some(height.to_string());
     }
 
     // Arrowheads are now rendered inline as polygon elements (matching C pikchr)


### PR DESCRIPTION
When enabled, always adds width and height attributes to the SVG element. This prevents inline SVGs from scaling up to fill their container.

I am, however, not entirely sure about whether this should do flooring or ceiling... Currently, I'm just using the existing code, which does flooring, I think.

closes #5 