### PR TITLE
Migrate from miette to ariadne for error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +127,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariadne"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
+dependencies = [
+ "unicode-width 0.2.2",
+ "yansi",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,12 +156,6 @@ checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "ascii_tree"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
 
 [[package]]
 name = "async-trait"
@@ -220,30 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
 dependencies = [
  "arrayvec",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -677,12 +648,6 @@ name = "escape8259"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
-
-[[package]]
-name = "escape_string"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e867569975c88fdf73833a30bd6e0978aa6ab6bd784b648fcece07450951ba"
 
 [[package]]
 name = "euclid"
@@ -1229,12 +1194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "glam"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,8 +1721,6 @@ version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "miette-derive",
  "owo-colors",
@@ -1920,15 +1877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,18 +1984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest_ascii_tree"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152b393638a9816cd3dedb5aea2fb60ab0b641315aa133cea219c8797e768fc"
-dependencies = [
- "ascii_tree",
- "escape_string",
- "pest",
- "pest_derive",
-]
-
-[[package]]
 name = "pest_derive"
 version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,14 +2064,13 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 name = "pikru"
 version = "1.0.1"
 dependencies = [
+ "ariadne",
  "camino",
  "datatest-stable",
  "enum_dispatch",
  "facet-svg",
  "glam",
- "miette",
  "pest",
- "pest_ascii_tree",
  "pest_derive",
  "pikru-compare",
  "thiserror",
@@ -2609,12 +2544,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -3684,6 +3613,12 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tracing = ["dep:tracing"]
 # 2D vector math for coordinates and geometry
 glam = "0.29"
 # Error reporting with source snippets and fancy terminal output
-miette = { version = "7.6.0", features = ["fancy"] }
+ariadne = "0.6"
 # PEG parser generator - core of the pikchr language parser
 pest = "2.8.4"
 pest_derive = "2.8.4"
@@ -55,8 +55,6 @@ camino = "1.2.1"
 tracing = "0.1.43"
 # Tracing subscriber for debug output in examples
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-# Pretty-print parse trees for debugging
-pest_ascii_tree = "0.1.0"
 
 [[test]]
 name = "pikchr_tests"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,8 @@
-//! Error types with rich diagnostics using miette
+//! Error types with rich diagnostics using ariadne
 //!
 //! These errors carry source spans for beautiful error messages.
 
-use miette::{Diagnostic, NamedSource, SourceSpan};
+use crate::types::Span;
 use thiserror::Error;
 
 /// Source context for error reporting
@@ -22,11 +22,6 @@ impl SourceContext {
             source: source.into(),
         }
     }
-
-    /// Create a NamedSource for miette
-    pub fn named_source(&self) -> NamedSource<String> {
-        NamedSource::new(&self.name, self.source.clone())
-    }
 }
 
 // ============================================================================
@@ -34,46 +29,19 @@ impl SourceContext {
 // ============================================================================
 
 /// Errors that occur during parsing
-#[derive(Error, Diagnostic, Debug)]
+#[derive(Error, Debug)]
 pub enum ParseError {
-    #[error("unexpected token")]
-    #[diagnostic(code(pikru::parse::unexpected_token))]
-    UnexpectedToken {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("found this")]
-        span: SourceSpan,
-        expected: String,
-    },
+    #[error("unexpected token: expected {expected}")]
+    UnexpectedToken { span: Span, expected: String },
 
     #[error("unterminated string")]
-    #[diagnostic(code(pikru::parse::unterminated_string))]
-    UnterminatedString {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("string starts here")]
-        span: SourceSpan,
-    },
+    UnterminatedString { span: Span },
 
     #[error("invalid number: {message}")]
-    #[diagnostic(code(pikru::parse::invalid_number))]
-    InvalidNumber {
-        message: String,
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("invalid number")]
-        span: SourceSpan,
-    },
+    InvalidNumber { message: String, span: Span },
 
     #[error("unknown keyword: {keyword}")]
-    #[diagnostic(code(pikru::parse::unknown_keyword))]
-    UnknownKeyword {
-        keyword: String,
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("unknown keyword")]
-        span: SourceSpan,
-    },
+    UnknownKeyword { keyword: String, span: Span },
 }
 
 // ============================================================================
@@ -81,118 +49,53 @@ pub enum ParseError {
 // ============================================================================
 
 /// Errors that occur during expression evaluation
-#[derive(Error, Diagnostic, Debug)]
+#[derive(Error, Debug)]
 pub enum EvalError {
     #[error("undefined variable: {name}")]
-    #[diagnostic(code(pikru::eval::undefined_variable))]
     UndefinedVariable {
         name: String,
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("not defined")]
-        span: SourceSpan,
-        #[help]
+        span: Span,
         suggestion: Option<String>,
     },
 
     #[error("unknown object: {name}")]
-    #[diagnostic(code(pikru::eval::unknown_object))]
     UnknownObject {
         name: String,
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("not found")]
-        span: SourceSpan,
-        #[help]
+        span: Span,
         suggestion: Option<String>,
     },
 
     #[error("cannot add two positions")]
-    #[diagnostic(
-        code(pikru::eval::cannot_add_positions),
-        help("use `pos - pos` to get displacement, or `pos + offset` to translate")
-    )]
-    CannotAddPositions {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("this is a position")]
-        lhs: SourceSpan,
-        #[label("this is also a position")]
-        rhs: SourceSpan,
-    },
+    CannotAddPositions { lhs: Span, rhs: Span },
 
     #[error("type mismatch: expected {expected}, got {got}")]
-    #[diagnostic(code(pikru::eval::type_mismatch))]
     TypeMismatch {
         expected: &'static str,
         got: &'static str,
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("this expression has type {got}")]
-        span: SourceSpan,
+        span: Span,
     },
 
     #[error("division by zero")]
-    #[diagnostic(code(pikru::eval::division_by_zero))]
-    DivisionByZero {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("divisor is zero")]
-        span: SourceSpan,
-    },
+    DivisionByZero { span: Span },
 
     #[error("sqrt of negative number")]
-    #[diagnostic(code(pikru::eval::sqrt_negative))]
-    SqrtNegative {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("this value is negative")]
-        span: SourceSpan,
-    },
+    SqrtNegative { span: Span },
 
-    #[error("ordinal out of range: {ordinal}")]
-    #[diagnostic(
-        code(pikru::eval::ordinal_out_of_range),
-        help("only {count} objects of this type exist")
-    )]
+    #[error("ordinal out of range: {ordinal} (only {count} objects exist)")]
     OrdinalOutOfRange {
         ordinal: u32,
         count: usize,
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("no such object")]
-        span: SourceSpan,
+        span: Span,
     },
 
-    #[error("invalid numeric value")]
-    #[diagnostic(code(pikru::eval::invalid_numeric))]
-    InvalidNumeric {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("this value is NaN or infinite")]
-        span: SourceSpan,
-    },
+    #[error("invalid numeric value (NaN or infinite)")]
+    InvalidNumeric { span: Span },
 
     #[error("no previous object")]
-    #[diagnostic(
-        code(pikru::eval::no_previous),
-        help("create at least one object before using 'previous'")
-    )]
-    NoPrevious {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("no previous object exists")]
-        span: SourceSpan,
-    },
+    NoPrevious { span: Span },
 
     #[error("cannot reference 'this' outside object definition")]
-    #[diagnostic(code(pikru::eval::no_this))]
-    NoThis {
-        #[source_code]
-        src: NamedSource<String>,
-        #[label("'this' not available here")]
-        span: SourceSpan,
-    },
+    NoThis { span: Span },
 }
 
 // ============================================================================
@@ -200,18 +103,15 @@ pub enum EvalError {
 // ============================================================================
 
 /// Errors that occur during rendering
-#[derive(Error, Diagnostic, Debug)]
+#[derive(Error, Debug)]
 pub enum RenderError {
     #[error("invalid scale: {value}")]
-    #[diagnostic(code(pikru::render::invalid_scale))]
     InvalidScale { value: f64 },
 
     #[error("empty diagram")]
-    #[diagnostic(code(pikru::render::empty_diagram))]
     EmptyDiagram,
 
     #[error("infinite or NaN in bounds")]
-    #[diagnostic(code(pikru::render::invalid_bounds))]
     InvalidBounds,
 }
 
@@ -220,26 +120,260 @@ pub enum RenderError {
 // ============================================================================
 
 /// Errors from the `error` statement in pikchr
-#[derive(Error, Diagnostic, Debug)]
+#[derive(Error, Debug)]
 #[error("{message}")]
-#[diagnostic(code(pikru::user_error))]
 pub struct UserError {
     pub message: String,
-    #[source_code]
-    pub src: NamedSource<String>,
-    #[label("error raised here")]
-    pub span: SourceSpan,
+    pub span: Span,
 }
 
 /// Assertion failure from the `assert` statement
-#[derive(Error, Diagnostic, Debug)]
+#[derive(Error, Debug)]
 #[error("assertion failed")]
-#[diagnostic(code(pikru::assertion_failed))]
 pub struct AssertionError {
-    #[source_code]
-    pub src: NamedSource<String>,
-    #[label("assertion failed here")]
-    pub span: SourceSpan,
-    #[help]
+    pub span: Span,
     pub details: Option<String>,
+}
+
+// ============================================================================
+// Unified Error Type
+// ============================================================================
+
+/// Main error type for pikru operations
+#[derive(Error, Debug)]
+pub enum PikruError {
+    #[error(transparent)]
+    Parse(#[from] ParseError),
+
+    #[error(transparent)]
+    Eval(#[from] EvalError),
+
+    #[error(transparent)]
+    Render(#[from] RenderError),
+
+    #[error(transparent)]
+    User(#[from] UserError),
+
+    #[error(transparent)]
+    Assertion(#[from] AssertionError),
+
+    #[error("{0}")]
+    Generic(String),
+}
+
+impl PikruError {
+    /// Convert the error to an ariadne report
+    pub fn to_report(&self, source_name: &str, source: &str) -> String {
+        use ariadne::{Color, Label, Report, ReportKind, Source};
+        use std::ops::Range;
+
+        // Helper to convert Span to Range<usize> with source ID
+        let to_range =
+            |span: &Span| -> (&str, Range<usize>) { (source_name, span.start..span.end) };
+
+        let mut output = Vec::new();
+
+        let report = match self {
+            PikruError::Parse(e) => match e {
+                ParseError::UnexpectedToken { span, expected } => {
+                    Report::build(ReportKind::Error, to_range(span))
+                        .with_message("unexpected token".to_string())
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message(format!("expected {}", expected))
+                                .with_color(Color::Red),
+                        )
+                        .finish()
+                }
+                ParseError::UnterminatedString { span } => {
+                    Report::build(ReportKind::Error, to_range(span))
+                        .with_message("unterminated string")
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message("string starts here")
+                                .with_color(Color::Red),
+                        )
+                        .finish()
+                }
+                ParseError::InvalidNumber { message, span } => {
+                    Report::build(ReportKind::Error, to_range(span))
+                        .with_message(format!("invalid number: {}", message))
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message("invalid number")
+                                .with_color(Color::Red),
+                        )
+                        .finish()
+                }
+                ParseError::UnknownKeyword { keyword, span } => {
+                    Report::build(ReportKind::Error, to_range(span))
+                        .with_message(format!("unknown keyword: {}", keyword))
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message("unknown keyword")
+                                .with_color(Color::Red),
+                        )
+                        .finish()
+                }
+            },
+            PikruError::Eval(e) => match e {
+                EvalError::UndefinedVariable {
+                    name,
+                    span,
+                    suggestion,
+                } => {
+                    let mut report = Report::build(ReportKind::Error, to_range(span))
+                        .with_message(format!("undefined variable: {}", name))
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message("not defined")
+                                .with_color(Color::Red),
+                        );
+                    if let Some(sugg) = suggestion {
+                        report = report.with_help(sugg.clone());
+                    }
+                    report.finish()
+                }
+                EvalError::UnknownObject {
+                    name,
+                    span,
+                    suggestion,
+                } => {
+                    let mut report = Report::build(ReportKind::Error, to_range(span))
+                        .with_message(format!("unknown object: {}", name))
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message("not found")
+                                .with_color(Color::Red),
+                        );
+                    if let Some(sugg) = suggestion {
+                        report = report.with_help(sugg.clone());
+                    }
+                    report.finish()
+                }
+                EvalError::CannotAddPositions { lhs, rhs } => {
+                    Report::build(ReportKind::Error, to_range(lhs))
+                        .with_message("cannot add two positions")
+                        .with_label(
+                            Label::new(to_range(lhs))
+                                .with_message("this is a position")
+                                .with_color(Color::Red),
+                        )
+                        .with_label(
+                            Label::new(to_range(rhs))
+                                .with_message("this is also a position")
+                                .with_color(Color::Red),
+                        )
+                        .with_help(
+                            "use `pos - pos` to get displacement, or `pos + offset` to translate",
+                        )
+                        .finish()
+                }
+                EvalError::TypeMismatch {
+                    expected,
+                    got,
+                    span,
+                } => Report::build(ReportKind::Error, to_range(span))
+                    .with_message(format!("type mismatch: expected {}, got {}", expected, got))
+                    .with_label(
+                        Label::new(to_range(span))
+                            .with_message(format!("this expression has type {}", got))
+                            .with_color(Color::Red),
+                    )
+                    .finish(),
+                EvalError::DivisionByZero { span } => {
+                    Report::build(ReportKind::Error, to_range(span))
+                        .with_message("division by zero")
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message("divisor is zero")
+                                .with_color(Color::Red),
+                        )
+                        .finish()
+                }
+                EvalError::SqrtNegative { span } => {
+                    Report::build(ReportKind::Error, to_range(span))
+                        .with_message("sqrt of negative number")
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message("this value is negative")
+                                .with_color(Color::Red),
+                        )
+                        .finish()
+                }
+                EvalError::OrdinalOutOfRange {
+                    ordinal,
+                    count,
+                    span,
+                } => Report::build(ReportKind::Error, to_range(span))
+                    .with_message(format!("ordinal out of range: {}", ordinal))
+                    .with_label(
+                        Label::new(to_range(span))
+                            .with_message("no such object")
+                            .with_color(Color::Red),
+                    )
+                    .with_help(format!("only {} objects of this type exist", count))
+                    .finish(),
+                EvalError::InvalidNumeric { span } => {
+                    Report::build(ReportKind::Error, to_range(span))
+                        .with_message("invalid numeric value")
+                        .with_label(
+                            Label::new(to_range(span))
+                                .with_message("this value is NaN or infinite")
+                                .with_color(Color::Red),
+                        )
+                        .finish()
+                }
+                EvalError::NoPrevious { span } => Report::build(ReportKind::Error, to_range(span))
+                    .with_message("no previous object")
+                    .with_label(
+                        Label::new(to_range(span))
+                            .with_message("no previous object exists")
+                            .with_color(Color::Red),
+                    )
+                    .with_help("create at least one object before using 'previous'")
+                    .finish(),
+                EvalError::NoThis { span } => Report::build(ReportKind::Error, to_range(span))
+                    .with_message("cannot reference 'this' outside object definition")
+                    .with_label(
+                        Label::new(to_range(span))
+                            .with_message("'this' not available here")
+                            .with_color(Color::Red),
+                    )
+                    .finish(),
+            },
+            PikruError::Render(e) => Report::build(ReportKind::Error, (source_name, 0..0))
+                .with_message(e.to_string())
+                .finish(),
+            PikruError::User(e) => Report::build(ReportKind::Error, to_range(&e.span))
+                .with_message(&e.message)
+                .with_label(
+                    Label::new(to_range(&e.span))
+                        .with_message("error raised here")
+                        .with_color(Color::Red),
+                )
+                .finish(),
+            PikruError::Assertion(e) => {
+                let mut report = Report::build(ReportKind::Error, to_range(&e.span))
+                    .with_message("assertion failed")
+                    .with_label(
+                        Label::new(to_range(&e.span))
+                            .with_message("assertion failed here")
+                            .with_color(Color::Red),
+                    );
+                if let Some(details) = &e.details {
+                    report = report.with_help(details.clone());
+                }
+                report.finish()
+            }
+            PikruError::Generic(msg) => Report::build(ReportKind::Error, (source_name, 0..0))
+                .with_message(msg)
+                .finish(),
+        };
+
+        report
+            .write((source_name, Source::from(source)), &mut output)
+            .unwrap();
+        String::from_utf8(output).unwrap()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub struct PikchrParser;
 
 /// Render pikchr source to SVG.
 ///
-/// Returns the SVG string on success, or an error with diagnostics.
+/// Returns the SVG string on success, or an error string with diagnostics.
 ///
 /// # Example
 ///
@@ -26,7 +26,7 @@ pub struct PikchrParser;
 /// let svg = pikru::pikchr(r#"box "Hello" arrow box "World""#).unwrap();
 /// assert!(svg.contains("<svg"));
 /// ```
-pub fn pikchr(source: &str) -> Result<String, miette::Report> {
+pub fn pikchr(source: &str) -> Result<String, String> {
     pikchr_with_options(source, &RenderOptions::default())
 }
 
@@ -43,18 +43,26 @@ pub fn pikchr(source: &str) -> Result<String, miette::Report> {
 /// let svg = pikchr_with_options(r#"box "Hello""#, &options).unwrap();
 /// assert!(svg.contains("light-dark("));
 /// ```
-pub fn pikchr_with_options(
-    source: &str,
-    options: &RenderOptions,
-) -> Result<String, miette::Report> {
+pub fn pikchr_with_options(source: &str, options: &RenderOptions) -> Result<String, String> {
+    use errors::PikruError;
+
     // Parse source into AST
-    let program = parse::parse(source)?;
+    let program = parse::parse(source).map_err(|e| {
+        let err: PikruError = e;
+        err.to_report("<input>", source)
+    })?;
 
     // Expand macros
-    let program = macros::expand_macros(program)?;
+    let program = macros::expand_macros(program).map_err(|e| {
+        let err: PikruError = e;
+        err.to_report("<input>", source)
+    })?;
 
     // Render to SVG
-    render::render_with_options(&program, options)
+    render::render_with_options(&program, options).map_err(|e| {
+        let err: PikruError = e;
+        err.to_report("<input>", source)
+    })
 }
 
 #[cfg(test)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,6 +3,7 @@
 //! Handles `define name { body }` and macro invocations.
 
 use crate::ast::*;
+use crate::errors::PikruError;
 use crate::parse;
 use std::collections::HashMap;
 
@@ -15,7 +16,7 @@ struct MacroDef {
 }
 
 /// Expand all macros in a program
-pub fn expand_macros(program: Program) -> Result<Program, miette::Report> {
+pub fn expand_macros(program: Program) -> Result<Program, PikruError> {
     let mut macros: HashMap<String, MacroDef> = HashMap::new();
     let mut expanded_statements = Vec::new();
 
@@ -35,7 +36,7 @@ fn process_statement(
     output: &mut Vec<Statement>,
     stmt: Statement,
     depth: usize,
-) -> Result<(), miette::Report> {
+) -> Result<(), PikruError> {
     match stmt {
         Statement::Define(def) => {
             // Store the macro definition
@@ -68,13 +69,12 @@ fn expand_macro_call(
     output: &mut Vec<Statement>,
     call: &MacroCall,
     depth: usize,
-) -> Result<(), miette::Report> {
+) -> Result<(), PikruError> {
     if depth >= MAX_EXPANSION_DEPTH {
-        return Err(miette::miette!(
+        return Err(PikruError::Generic(format!(
             "Macro expansion depth exceeded (max {}). Possible infinite recursion in macro '{}'",
-            MAX_EXPANSION_DEPTH,
-            call.name
-        ));
+            MAX_EXPANSION_DEPTH, call.name
+        )));
     }
 
     // Look up the macro

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,14 +1,15 @@
 //! Parse pest pairs into AST nodes
 
 use crate::ast::*;
+use crate::errors::PikruError;
 use crate::{PikchrParser, Rule};
 use pest::Parser;
 use pest::iterators::Pair;
 
 /// Parse pikchr source into AST
-pub fn parse(source: &str) -> Result<Program, miette::Report> {
+pub fn parse(source: &str) -> Result<Program, PikruError> {
     let pairs = PikchrParser::parse(Rule::program, source)
-        .map_err(|e| miette::miette!("Parse error: {}", e))?;
+        .map_err(|e| PikruError::Generic(format!("Parse error: {}", e)))?;
 
     let mut statements = Vec::new();
     for pair in pairs {
@@ -24,7 +25,7 @@ pub fn parse(source: &str) -> Result<Program, miette::Report> {
     Ok(Program { statements })
 }
 
-fn parse_statement_list(pair: Pair<Rule>) -> Result<Vec<Statement>, miette::Report> {
+fn parse_statement_list(pair: Pair<Rule>) -> Result<Vec<Statement>, PikruError> {
     let mut statements = Vec::new();
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::statement {
@@ -34,7 +35,7 @@ fn parse_statement_list(pair: Pair<Rule>) -> Result<Vec<Statement>, miette::Repo
     Ok(statements)
 }
 
-fn parse_statement(pair: Pair<Rule>) -> Result<Statement, miette::Report> {
+fn parse_statement(pair: Pair<Rule>) -> Result<Statement, PikruError> {
     let inner = pair.into_inner().next().unwrap();
     match inner.as_rule() {
         Rule::labeled_statement => Ok(Statement::Labeled(parse_labeled_statement(inner)?)),
@@ -46,25 +47,25 @@ fn parse_statement(pair: Pair<Rule>) -> Result<Statement, miette::Report> {
         Rule::print_stmt => Ok(Statement::Print(parse_print(inner)?)),
         Rule::error_stmt => Ok(Statement::Error(parse_error_stmt(inner)?)),
         Rule::object_stmt => Ok(Statement::Object(parse_object_stmt(inner)?)),
-        _ => Err(miette::miette!(
+        _ => Err(PikruError::Generic(format!(
             "Unexpected rule in statement: {:?}",
             inner.as_rule()
-        )),
+        ))),
     }
 }
 
-fn parse_direction(pair: Pair<Rule>) -> Result<Direction, miette::Report> {
+fn parse_direction(pair: Pair<Rule>) -> Result<Direction, PikruError> {
     let s = pair.as_str().trim();
     match s {
         "up" => Ok(Direction::Up),
         "down" => Ok(Direction::Down),
         "left" => Ok(Direction::Left),
         "right" => Ok(Direction::Right),
-        _ => Err(miette::miette!("Invalid direction: {}", s)),
+        _ => Err(PikruError::Generic(format!("Invalid direction: {}", s))),
     }
 }
 
-fn parse_assignment(pair: Pair<Rule>) -> Result<Assignment, miette::Report> {
+fn parse_assignment(pair: Pair<Rule>) -> Result<Assignment, PikruError> {
     let mut inner = pair.into_inner();
     let lvalue = parse_lvalue(inner.next().unwrap())?;
     let op = parse_assign_op(inner.next().unwrap())?;
@@ -72,7 +73,7 @@ fn parse_assignment(pair: Pair<Rule>) -> Result<Assignment, miette::Report> {
     Ok(Assignment { lvalue, op, rvalue })
 }
 
-fn parse_lvalue(pair: Pair<Rule>) -> Result<LValue, miette::Report> {
+fn parse_lvalue(pair: Pair<Rule>) -> Result<LValue, PikruError> {
     // Grammar: lvalue = { variable | "fill" | "color" | "thickness" }
     // If it's a literal like "fill", there may be no inner children
     let pair_str = pair.as_str();
@@ -86,7 +87,7 @@ fn parse_lvalue(pair: Pair<Rule>) -> Result<LValue, miette::Report> {
                     "fill" => Ok(LValue::Fill),
                     "color" => Ok(LValue::Color),
                     "thickness" => Ok(LValue::Thickness),
-                    _ => Err(miette::miette!("Invalid lvalue: {}", s)),
+                    _ => Err(PikruError::Generic(format!("Invalid lvalue: {}", s))),
                 }
             }
         }
@@ -96,12 +97,15 @@ fn parse_lvalue(pair: Pair<Rule>) -> Result<LValue, miette::Report> {
             "fill" => Ok(LValue::Fill),
             "color" => Ok(LValue::Color),
             "thickness" => Ok(LValue::Thickness),
-            s => Err(miette::miette!("Invalid lvalue with no children: {}", s)),
+            s => Err(PikruError::Generic(format!(
+                "Invalid lvalue with no children: {}",
+                s
+            ))),
         }
     }
 }
 
-fn parse_variable_name(pair: Pair<Rule>) -> Result<String, miette::Report> {
+fn parse_variable_name(pair: Pair<Rule>) -> Result<String, PikruError> {
     // cref: pik_value (pikchr.c) - variables can be "$foo" or "foo"
     // The "$" prefix is part of the variable name - "$margin" is different from "margin"
     // This is important because system variables like "margin", "thickness" etc. should not
@@ -123,35 +127,38 @@ fn parse_variable_name(pair: Pair<Rule>) -> Result<String, miette::Report> {
     }
 }
 
-fn parse_assign_op(pair: Pair<Rule>) -> Result<AssignOp, miette::Report> {
+fn parse_assign_op(pair: Pair<Rule>) -> Result<AssignOp, PikruError> {
     match pair.as_str() {
         "=" => Ok(AssignOp::Assign),
         "+=" => Ok(AssignOp::AddAssign),
         "-=" => Ok(AssignOp::SubAssign),
         "*=" => Ok(AssignOp::MulAssign),
         "/=" => Ok(AssignOp::DivAssign),
-        s => Err(miette::miette!("Invalid assign op: {}", s)),
+        s => Err(PikruError::Generic(format!("Invalid assign op: {}", s))),
     }
 }
 
-fn parse_rvalue(pair: Pair<Rule>) -> Result<RValue, miette::Report> {
+fn parse_rvalue(pair: Pair<Rule>) -> Result<RValue, PikruError> {
     let inner = pair.into_inner().next().unwrap();
     match inner.as_rule() {
         Rule::expr => Ok(RValue::Expr(parse_expr(inner)?)),
         Rule::PLACENAME => Ok(RValue::PlaceName(inner.as_str().to_string())),
         Rule::HEX_COLOR => Ok(RValue::PlaceName(inner.as_str().to_string())), // Pass hex color as-is
-        _ => Err(miette::miette!("Invalid rvalue: {:?}", inner.as_rule())),
+        _ => Err(PikruError::Generic(format!(
+            "Invalid rvalue: {:?}",
+            inner.as_rule()
+        ))),
     }
 }
 
-fn parse_define(pair: Pair<Rule>) -> Result<Define, miette::Report> {
+fn parse_define(pair: Pair<Rule>) -> Result<Define, PikruError> {
     let mut inner = pair.into_inner();
     let name = inner.next().unwrap().as_str().to_string();
     let body = inner.next().unwrap().as_str().to_string();
     Ok(Define { name, body })
 }
 
-fn parse_macro_call(pair: Pair<Rule>) -> Result<MacroCall, miette::Report> {
+fn parse_macro_call(pair: Pair<Rule>) -> Result<MacroCall, PikruError> {
     let mut inner = pair.into_inner();
     let name = inner.next().unwrap().as_str().to_string();
     let args = if let Some(args_pair) = inner.next() {
@@ -162,7 +169,7 @@ fn parse_macro_call(pair: Pair<Rule>) -> Result<MacroCall, miette::Report> {
     Ok(MacroCall { name, args })
 }
 
-fn parse_macro_args(pair: Pair<Rule>) -> Result<Vec<MacroArg>, miette::Report> {
+fn parse_macro_args(pair: Pair<Rule>) -> Result<Vec<MacroArg>, PikruError> {
     let mut args = Vec::new();
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::macro_arg {
@@ -172,31 +179,34 @@ fn parse_macro_args(pair: Pair<Rule>) -> Result<Vec<MacroArg>, miette::Report> {
     Ok(args)
 }
 
-fn parse_macro_arg(pair: Pair<Rule>) -> Result<MacroArg, miette::Report> {
+fn parse_macro_arg(pair: Pair<Rule>) -> Result<MacroArg, PikruError> {
     let inner = pair.into_inner().next().unwrap();
     match inner.as_rule() {
         Rule::STRING => Ok(MacroArg::String(parse_string(inner)?)),
         Rule::expr => Ok(MacroArg::Expr(parse_expr(inner)?)),
         Rule::IDENT => Ok(MacroArg::Ident(inner.as_str().to_string())),
-        _ => Err(miette::miette!("Invalid macro arg: {:?}", inner.as_rule())),
+        _ => Err(PikruError::Generic(format!(
+            "Invalid macro arg: {:?}",
+            inner.as_rule()
+        ))),
     }
 }
 
-fn parse_assert(pair: Pair<Rule>) -> Result<Assert, miette::Report> {
+fn parse_assert(pair: Pair<Rule>) -> Result<Assert, PikruError> {
     let mut inner = pair.into_inner().peekable();
     // Grammar: "assert" ~ "(" ~ (expr ~ "==" ~ expr | position ~ "==" ~ position) ~ ")"
     // Keywords/literals like "assert", "(", "==", ")" are not captured as children
 
     let first = inner
         .next()
-        .ok_or_else(|| miette::miette!("Empty assert statement"))?;
+        .ok_or_else(|| PikruError::Generic("Empty assert statement".to_string()))?;
 
     let condition = if first.as_rule() == Rule::expr {
         let left = parse_expr(first)?;
         // "==" is a literal, not captured - next should be the second expr
         let right_pair = inner
             .next()
-            .ok_or_else(|| miette::miette!("Missing right side of assert"))?;
+            .ok_or_else(|| PikruError::Generic("Missing right side of assert".to_string()))?;
         let right = parse_expr(right_pair)?;
         AssertCondition::ExprEqual(left, right)
     } else if first.as_rule() == Rule::position {
@@ -204,19 +214,19 @@ fn parse_assert(pair: Pair<Rule>) -> Result<Assert, miette::Report> {
         // "==" is a literal, not captured - next should be the second position
         let right_pair = inner
             .next()
-            .ok_or_else(|| miette::miette!("Missing right side of assert"))?;
+            .ok_or_else(|| PikruError::Generic("Missing right side of assert".to_string()))?;
         let right = parse_position(right_pair)?;
         AssertCondition::PositionEqual(Box::new(left), Box::new(right))
     } else {
-        return Err(miette::miette!(
+        return Err(PikruError::Generic(format!(
             "Invalid assert condition: {:?}",
             first.as_rule()
-        ));
+        )));
     };
     Ok(Assert { condition })
 }
 
-fn parse_print(pair: Pair<Rule>) -> Result<Print, miette::Report> {
+fn parse_print(pair: Pair<Rule>) -> Result<Print, PikruError> {
     let mut args = Vec::new();
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::print_args {
@@ -237,13 +247,13 @@ fn parse_print(pair: Pair<Rule>) -> Result<Print, miette::Report> {
     Ok(Print { args })
 }
 
-fn parse_error_stmt(pair: Pair<Rule>) -> Result<ErrorStmt, miette::Report> {
+fn parse_error_stmt(pair: Pair<Rule>) -> Result<ErrorStmt, PikruError> {
     let inner = pair.into_inner().next().unwrap();
     let message = parse_string(inner)?;
     Ok(ErrorStmt { message })
 }
 
-fn parse_labeled_statement(pair: Pair<Rule>) -> Result<LabeledStatement, miette::Report> {
+fn parse_labeled_statement(pair: Pair<Rule>) -> Result<LabeledStatement, PikruError> {
     let mut inner = pair.into_inner();
     let label = inner.next().unwrap().as_str().to_string();
     let content_pair = inner.next().unwrap();
@@ -251,16 +261,16 @@ fn parse_labeled_statement(pair: Pair<Rule>) -> Result<LabeledStatement, miette:
         Rule::position => LabeledContent::Position(parse_position(content_pair)?),
         Rule::object_stmt => LabeledContent::Object(parse_object_stmt(content_pair)?),
         _ => {
-            return Err(miette::miette!(
+            return Err(PikruError::Generic(format!(
                 "Invalid labeled content: {:?}",
                 content_pair.as_rule()
-            ));
+            )));
         }
     };
     Ok(LabeledStatement { label, content })
 }
 
-fn parse_object_stmt(pair: Pair<Rule>) -> Result<ObjectStatement, miette::Report> {
+fn parse_object_stmt(pair: Pair<Rule>) -> Result<ObjectStatement, PikruError> {
     let mut inner = pair.into_inner();
     let basetype = parse_basetype(inner.next().unwrap())?;
     let mut attributes = Vec::new();
@@ -279,7 +289,7 @@ fn parse_object_stmt(pair: Pair<Rule>) -> Result<ObjectStatement, miette::Report
     })
 }
 
-fn parse_basetype(pair: Pair<Rule>) -> Result<BaseType, miette::Report> {
+fn parse_basetype(pair: Pair<Rule>) -> Result<BaseType, PikruError> {
     let mut inner = pair.into_inner();
     let first = inner.next().unwrap();
     match first.as_rule() {
@@ -298,11 +308,14 @@ fn parse_basetype(pair: Pair<Rule>) -> Result<BaseType, miette::Report> {
             let statements = parse_statement_list(first.into_inner().next().unwrap())?;
             Ok(BaseType::Sublist(statements))
         }
-        _ => Err(miette::miette!("Invalid basetype: {:?}", first.as_rule())),
+        _ => Err(PikruError::Generic(format!(
+            "Invalid basetype: {:?}",
+            first.as_rule()
+        ))),
     }
 }
 
-fn parse_classname(pair: Pair<Rule>) -> Result<ClassName, miette::Report> {
+fn parse_classname(pair: Pair<Rule>) -> Result<ClassName, PikruError> {
     match pair.as_str() {
         "arc" => Ok(ClassName::Arc),
         "arrow" => Ok(ClassName::Arrow),
@@ -318,11 +331,11 @@ fn parse_classname(pair: Pair<Rule>) -> Result<ClassName, miette::Report> {
         "oval" => Ok(ClassName::Oval),
         "spline" => Ok(ClassName::Spline),
         "text" => Ok(ClassName::Text),
-        s => Err(miette::miette!("Invalid classname: {}", s)),
+        s => Err(PikruError::Generic(format!("Invalid classname: {}", s))),
     }
 }
 
-fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute, miette::Report> {
+fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute, PikruError> {
     let pair_str = pair.as_str().to_string();
 
     // Debug: log what attribute we're parsing
@@ -338,7 +351,10 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute, miette::Report> {
             "fit" => Ok(Attribute::Fit),
             "then" => Ok(Attribute::Then(None)),
             "same" => Ok(Attribute::Same(None)),
-            s => Err(miette::miette!("Unexpected empty attribute: {}", s)),
+            s => Err(PikruError::Generic(format!(
+                "Unexpected empty attribute: {}",
+                s
+            ))),
         };
     }
 
@@ -522,13 +538,13 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute, miette::Report> {
                             let heading_expr = parse_expr(inner.next().unwrap())?;
                             Ok(Attribute::Heading(relexpr, heading_expr))
                         } else {
-                            Err(miette::miette!(
+                            Err(PikruError::Generic(format!(
                                 "Unexpected after 'go': {:?}",
                                 next.as_rule()
-                            ))
+                            )))
                         }
                     } else {
-                        Err(miette::miette!("Nothing after 'go'"))
+                        Err(PikruError::Generic("Nothing after 'go'".to_string()))
                     }
                 }
                 "close" => Ok(Attribute::Close),
@@ -572,11 +588,11 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute, miette::Report> {
                     let obj = parse_object(inner.next().unwrap())?;
                     Ok(Attribute::Behind(obj))
                 }
-                _ => Err(miette::miette!(
+                _ => Err(PikruError::Generic(format!(
                     "Unexpected attribute: {} (rule: {:?})",
                     s,
                     first.as_rule()
-                )),
+                ))),
             }
         }
     }
@@ -586,7 +602,7 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute, miette::Report> {
 fn parse_direction_attribute<'a, I>(
     inner: &mut std::iter::Peekable<I>,
     pair_str: &str,
-) -> Result<Attribute, miette::Report>
+) -> Result<Attribute, PikruError>
 where
     I: Iterator<Item = Pair<'a, Rule>>,
 {
@@ -651,7 +667,7 @@ where
 fn parse_then_clause<'a, I>(
     inner: &mut std::iter::Peekable<I>,
     pair_str: &str,
-) -> Result<Attribute, miette::Report>
+) -> Result<Attribute, PikruError>
 where
     I: Iterator<Item = Pair<'a, Rule>>,
 {
@@ -749,34 +765,34 @@ where
     }
 }
 
-fn parse_numproperty(pair: Pair<Rule>) -> Result<NumProperty, miette::Report> {
+fn parse_numproperty(pair: Pair<Rule>) -> Result<NumProperty, PikruError> {
     match pair.as_str() {
         "height" | "ht" => Ok(NumProperty::Height),
         "width" | "wid" => Ok(NumProperty::Width),
         "radius" | "rad" => Ok(NumProperty::Radius),
         "diameter" => Ok(NumProperty::Diameter),
         "thickness" => Ok(NumProperty::Thickness),
-        s => Err(miette::miette!("Invalid numproperty: {}", s)),
+        s => Err(PikruError::Generic(format!("Invalid numproperty: {}", s))),
     }
 }
 
-fn parse_dashproperty(pair: Pair<Rule>) -> Result<DashProperty, miette::Report> {
+fn parse_dashproperty(pair: Pair<Rule>) -> Result<DashProperty, PikruError> {
     match pair.as_str() {
         "dotted" => Ok(DashProperty::Dotted),
         "dashed" => Ok(DashProperty::Dashed),
-        s => Err(miette::miette!("Invalid dashproperty: {}", s)),
+        s => Err(PikruError::Generic(format!("Invalid dashproperty: {}", s))),
     }
 }
 
-fn parse_colorproperty(pair: Pair<Rule>) -> Result<ColorProperty, miette::Report> {
+fn parse_colorproperty(pair: Pair<Rule>) -> Result<ColorProperty, PikruError> {
     match pair.as_str() {
         "fill" => Ok(ColorProperty::Fill),
         "color" => Ok(ColorProperty::Color),
-        s => Err(miette::miette!("Invalid colorproperty: {}", s)),
+        s => Err(PikruError::Generic(format!("Invalid colorproperty: {}", s))),
     }
 }
 
-fn parse_boolproperty(pair: Pair<Rule>) -> Result<BoolProperty, miette::Report> {
+fn parse_boolproperty(pair: Pair<Rule>) -> Result<BoolProperty, PikruError> {
     match pair.as_str() {
         "cw" => Ok(BoolProperty::Clockwise),
         "ccw" => Ok(BoolProperty::CounterClockwise),
@@ -787,17 +803,17 @@ fn parse_boolproperty(pair: Pair<Rule>) -> Result<BoolProperty, miette::Report> 
         "<->" | "&leftrightarrow;" | "↔" => Ok(BoolProperty::ArrowBoth),
         "->" | "&rarr;" | "&rightarrow;" | "→" => Ok(BoolProperty::ArrowRight),
         "<-" | "&larr;" | "&leftarrow;" | "←" => Ok(BoolProperty::ArrowLeft),
-        s => Err(miette::miette!("Invalid boolproperty: {}", s)),
+        s => Err(PikruError::Generic(format!("Invalid boolproperty: {}", s))),
     }
 }
 
-fn parse_withclause(pair: Pair<Rule>) -> Result<WithClause, miette::Report> {
+fn parse_withclause(pair: Pair<Rule>) -> Result<WithClause, PikruError> {
     let mut inner = pair.into_inner().peekable();
 
     // First child should be dot_edge or EDGEPT
     let edge_pair = inner
         .next()
-        .ok_or_else(|| miette::miette!("Empty withclause"))?;
+        .ok_or_else(|| PikruError::Generic("Empty withclause".to_string()))?;
 
     let edge = match edge_pair.as_rule() {
         Rule::dot_edge => {
@@ -823,10 +839,10 @@ fn parse_withclause(pair: Pair<Rule>) -> Result<WithClause, miette::Report> {
             });
         }
         _ => {
-            return Err(miette::miette!(
+            return Err(PikruError::Generic(format!(
                 "Invalid withclause edge: {:?}",
                 edge_pair.as_rule()
-            ));
+            )));
         }
     };
 
@@ -835,13 +851,15 @@ fn parse_withclause(pair: Pair<Rule>) -> Result<WithClause, miette::Report> {
     let position = if let Some(pos_pair) = inner.next() {
         parse_position(pos_pair)?
     } else {
-        return Err(miette::miette!("Missing position in withclause"));
+        return Err(PikruError::Generic(
+            "Missing position in withclause".to_string(),
+        ));
     };
 
     Ok(WithClause { edge, position })
 }
 
-fn parse_edgepoint_str(s: &str) -> Result<EdgePoint, miette::Report> {
+fn parse_edgepoint_str(s: &str) -> Result<EdgePoint, PikruError> {
     match s.trim() {
         "north" | "n" => Ok(EdgePoint::North),
         "south" | "s" => Ok(EdgePoint::South),
@@ -858,11 +876,14 @@ fn parse_edgepoint_str(s: &str) -> Result<EdgePoint, miette::Report> {
         "nw" => Ok(EdgePoint::NorthWest),
         "se" => Ok(EdgePoint::SouthEast),
         "sw" => Ok(EdgePoint::SouthWest),
-        _ => Err(miette::miette!("Invalid edgepoint string: {}", s)),
+        _ => Err(PikruError::Generic(format!(
+            "Invalid edgepoint string: {}",
+            s
+        ))),
     }
 }
 
-fn parse_textposition(pair: Pair<Rule>) -> Result<TextPosition, miette::Report> {
+fn parse_textposition(pair: Pair<Rule>) -> Result<TextPosition, PikruError> {
     let mut attrs = Vec::new();
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::textattr {
@@ -872,7 +893,7 @@ fn parse_textposition(pair: Pair<Rule>) -> Result<TextPosition, miette::Report> 
     Ok(TextPosition { attrs })
 }
 
-fn parse_textattr(pair: Pair<Rule>) -> Result<TextAttr, miette::Report> {
+fn parse_textattr(pair: Pair<Rule>) -> Result<TextAttr, PikruError> {
     match pair.as_str() {
         "above" => Ok(TextAttr::Above),
         "below" => Ok(TextAttr::Below),
@@ -885,11 +906,11 @@ fn parse_textattr(pair: Pair<Rule>) -> Result<TextAttr, miette::Report> {
         "big" => Ok(TextAttr::Big),
         "small" => Ok(TextAttr::Small),
         "aligned" => Ok(TextAttr::Aligned),
-        s => Err(miette::miette!("Invalid textattr: {}", s)),
+        s => Err(PikruError::Generic(format!("Invalid textattr: {}", s))),
     }
 }
 
-fn parse_relexpr(pair: Pair<Rule>) -> Result<RelExpr, miette::Report> {
+fn parse_relexpr(pair: Pair<Rule>) -> Result<RelExpr, PikruError> {
     let mut inner = pair.into_inner();
     let expr = parse_expr(inner.next().unwrap())?;
     // Check if there's a percent rule following the expression
@@ -900,7 +921,7 @@ fn parse_relexpr(pair: Pair<Rule>) -> Result<RelExpr, miette::Report> {
     Ok(RelExpr { expr, is_percent })
 }
 
-fn parse_expr(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
+fn parse_expr(pair: Pair<Rule>) -> Result<Expr, PikruError> {
     // expr = term ~ (add_op ~ term)*
     let mut inner = pair.into_inner();
     let mut result = parse_term(inner.next().unwrap())?;
@@ -921,7 +942,7 @@ fn parse_expr(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
     Ok(result)
 }
 
-fn parse_term(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
+fn parse_term(pair: Pair<Rule>) -> Result<Expr, PikruError> {
     // term = prefix? ~ primary ~ (mul_op ~ prefix? ~ primary)*
     let mut inner = pair.into_inner().peekable();
 
@@ -932,7 +953,12 @@ fn parse_term(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
         prefix = Some(match p.as_str() {
             "-" => UnaryOp::Neg,
             "+" => UnaryOp::Pos,
-            _ => return Err(miette::miette!("Invalid prefix: {}", p.as_str())),
+            _ => {
+                return Err(PikruError::Generic(format!(
+                    "Invalid prefix: {}",
+                    p.as_str()
+                )));
+            }
         });
     }
 
@@ -963,7 +989,7 @@ fn parse_term(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
             rhs_prefix = Some(match p.as_str() {
                 "-" => UnaryOp::Neg,
                 "+" => UnaryOp::Pos,
-                _ => return Err(miette::miette!("Invalid prefix")),
+                _ => return Err(PikruError::Generic("Invalid prefix".to_string())),
             });
         }
 
@@ -980,7 +1006,7 @@ fn parse_term(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
     Ok(result)
 }
 
-fn parse_primary(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
+fn parse_primary(pair: Pair<Rule>) -> Result<Expr, PikruError> {
     let mut inner = pair.into_inner().peekable();
     let first = inner.next().unwrap();
 
@@ -998,13 +1024,13 @@ fn parse_primary(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
             // "vertex" and "of" are literals, not captured
             let nth = parse_nth_from_str(first.as_str())?;
             // Next should be object, then dot_xy
-            let obj_pair = inner
-                .next()
-                .ok_or_else(|| miette::miette!("Missing object in vertex expression"))?;
+            let obj_pair = inner.next().ok_or_else(|| {
+                PikruError::Generic("Missing object in vertex expression".to_string())
+            })?;
             let obj = parse_object(obj_pair)?;
-            let coord_pair = inner
-                .next()
-                .ok_or_else(|| miette::miette!("Missing coordinate in vertex expression"))?;
+            let coord_pair = inner.next().ok_or_else(|| {
+                PikruError::Generic("Missing coordinate in vertex expression".to_string())
+            })?;
             let coord = parse_coord(coord_pair)?;
             Ok(Expr::VertexCoord(nth, obj, coord))
         }
@@ -1022,7 +1048,9 @@ fn parse_primary(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
                             Ok(Expr::ObjectEdgeCoord(obj, ep, coord))
                         } else {
                             // object.edge without .xy - this is a place, not an expr
-                            Err(miette::miette!("object.edge is a place, not an expression"))
+                            Err(PikruError::Generic(
+                                "object.edge is a place, not an expression".to_string(),
+                            ))
                         }
                     }
                     Rule::dot_xy => {
@@ -1036,14 +1064,16 @@ fn parse_primary(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
                         let prop = parse_numproperty(prop_pair)?;
                         Ok(Expr::ObjectProp(obj, prop))
                     }
-                    _ => Err(miette::miette!(
+                    _ => Err(PikruError::Generic(format!(
                         "Unexpected after object in primary: {:?}",
                         next.as_rule()
-                    )),
+                    ))),
                 }
             } else {
                 // Bare object - this should be a place, not an expr
-                Err(miette::miette!("Bare object is a place, not an expression"))
+                Err(PikruError::Generic(
+                    "Bare object is a place, not an expression".to_string(),
+                ))
             }
         }
         _ => {
@@ -1053,17 +1083,17 @@ fn parse_primary(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
                 "fill" => Ok(Expr::BuiltinVar(BuiltinVar::Fill)),
                 "color" => Ok(Expr::BuiltinVar(BuiltinVar::Color)),
                 "thickness" => Ok(Expr::BuiltinVar(BuiltinVar::Thickness)),
-                _ => Err(miette::miette!(
+                _ => Err(PikruError::Generic(format!(
                     "Unexpected primary: {} (rule: {:?})",
                     s,
                     first.as_rule()
-                )),
+                ))),
             }
         }
     }
 }
 
-fn parse_coord(pair: Pair<Rule>) -> Result<Coord, miette::Report> {
+fn parse_coord(pair: Pair<Rule>) -> Result<Coord, PikruError> {
     // dot_xy = { "." ~ ("x" | "y") } - literals don't create children
     // So we need to look at the string content
     let s = pair.as_str();
@@ -1072,20 +1102,20 @@ fn parse_coord(pair: Pair<Rule>) -> Result<Coord, miette::Report> {
     } else if s.contains('y') {
         Ok(Coord::Y)
     } else {
-        Err(miette::miette!("Invalid coord: {}", s))
+        Err(PikruError::Generic(format!("Invalid coord: {}", s)))
     }
 }
 
-fn parse_nth_from_str(s: &str) -> Result<Nth, miette::Report> {
+fn parse_nth_from_str(s: &str) -> Result<Nth, PikruError> {
     // Parse ordinal like "1st", "2nd", "3rd", etc.
     let num: u32 = s
         .trim_end_matches(|c: char| !c.is_ascii_digit())
         .parse()
-        .map_err(|_| miette::miette!("Invalid ordinal: {}", s))?;
+        .map_err(|_| PikruError::Generic(format!("Invalid ordinal: {}", s)))?;
     Ok(Nth::Ordinal(num, false, None))
 }
 
-fn parse_func_call(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
+fn parse_func_call(pair: Pair<Rule>) -> Result<Expr, PikruError> {
     let mut inner = pair.into_inner();
     let func_pair = inner.next().unwrap();
     let func = match func_pair.as_str() {
@@ -1096,7 +1126,7 @@ fn parse_func_call(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
         "sqrt" => Function::Sqrt,
         "max" => Function::Max,
         "min" => Function::Min,
-        s => return Err(miette::miette!("Unknown function: {}", s)),
+        s => return Err(PikruError::Generic(format!("Unknown function: {}", s))),
     };
     let mut args = Vec::new();
     for arg in inner {
@@ -1107,20 +1137,20 @@ fn parse_func_call(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
     Ok(Expr::FuncCall(FuncCall { func, args }))
 }
 
-fn parse_dist_call(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
+fn parse_dist_call(pair: Pair<Rule>) -> Result<Expr, PikruError> {
     let mut inner = pair.into_inner();
     let pos1 = parse_position(inner.next().unwrap())?;
     let pos2 = parse_position(inner.next().unwrap())?;
     Ok(Expr::DistCall(Box::new(pos1), Box::new(pos2)))
 }
 
-fn parse_number(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
+fn parse_number(pair: Pair<Rule>) -> Result<Expr, PikruError> {
     let raw = pair.as_str();
 
     // Hex literal (kept as-is, like C)
     if raw.starts_with("0x") || raw.starts_with("0X") {
         let n = u64::from_str_radix(&raw[2..], 16)
-            .map_err(|e| miette::miette!("Invalid hex number: {}", e))?;
+            .map_err(|e| PikruError::Generic(format!("Invalid hex number: {}", e)))?;
         return Ok(Expr::Number(n as f64));
     }
 
@@ -1137,7 +1167,7 @@ fn parse_number(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
 
     let mut n: f64 = number_part
         .parse()
-        .map_err(|e| miette::miette!("Invalid number: {}", e))?;
+        .map_err(|e| PikruError::Generic(format!("Invalid number: {}", e)))?;
 
     // Convert to inches to mirror pikchr.c:pik_atof
     if let Some(unit) = unit_suffix {
@@ -1155,13 +1185,13 @@ fn parse_number(pair: Pair<Rule>) -> Result<Expr, miette::Report> {
     Ok(Expr::Number(n))
 }
 
-fn parse_position(pair: Pair<Rule>) -> Result<Position, miette::Report> {
+fn parse_position(pair: Pair<Rule>) -> Result<Position, PikruError> {
     let pair_str = pair.as_str().to_string();
     let mut inner = pair.into_inner();
 
     let child = inner
         .next()
-        .ok_or_else(|| miette::miette!("Empty position: {}", pair_str))?;
+        .ok_or_else(|| PikruError::Generic(format!("Empty position: {}", pair_str)))?;
 
     match child.as_rule() {
         Rule::pos_tuple => {
@@ -1267,20 +1297,20 @@ fn parse_position(pair: Pair<Rule>) -> Result<Position, miette::Report> {
             let place = parse_place(kids.next().unwrap())?;
             Ok(Position::Place(place))
         }
-        _ => Err(miette::miette!(
+        _ => Err(PikruError::Generic(format!(
             "Unexpected position rule: {:?} in '{}'",
             child.as_rule(),
             pair_str
-        )),
+        ))),
     }
 }
 
-fn parse_place(pair: Pair<Rule>) -> Result<Place, miette::Report> {
+fn parse_place(pair: Pair<Rule>) -> Result<Place, PikruError> {
     let pair_str = pair.as_str();
     let mut inner = pair.into_inner().peekable();
     let first = match inner.peek() {
         Some(p) => p,
-        None => return Err(miette::miette!("Empty place: {}", pair_str)),
+        None => return Err(PikruError::Generic(format!("Empty place: {}", pair_str))),
     };
 
     match first.as_rule() {
@@ -1293,10 +1323,10 @@ fn parse_place(pair: Pair<Rule>) -> Result<Place, miette::Report> {
                 let obj = parse_object(obj_pair)?;
                 Ok(Place::Vertex(nth, obj))
             } else {
-                Err(miette::miette!(
+                Err(PikruError::Generic(format!(
                     "Missing object in NTH vertex of object: {}",
                     pair_str
-                ))
+                )))
             }
         }
         Rule::EDGEPT => {
@@ -1311,11 +1341,10 @@ fn parse_place(pair: Pair<Rule>) -> Result<Place, miette::Report> {
             } else {
                 // No object found - maybe this is just a bare edgepoint
                 // Return as a placeholder object
-                Err(miette::miette!(
+                Err(PikruError::Generic(format!(
                     "Missing object in EDGEPT of object: {} (edgepoint: {:?})",
-                    pair_str,
-                    ep
-                ))
+                    pair_str, ep
+                )))
             }
         }
         Rule::object => {
@@ -1329,20 +1358,26 @@ fn parse_place(pair: Pair<Rule>) -> Result<Place, miette::Report> {
                 Ok(Place::Object(obj))
             }
         }
-        _ => Err(miette::miette!("Invalid place: {:?}", first.as_rule())),
+        _ => Err(PikruError::Generic(format!(
+            "Invalid place: {:?}",
+            first.as_rule()
+        ))),
     }
 }
 
-fn parse_object(pair: Pair<Rule>) -> Result<Object, miette::Report> {
+fn parse_object(pair: Pair<Rule>) -> Result<Object, PikruError> {
     let inner = pair.into_inner().next().unwrap();
     match inner.as_rule() {
         Rule::objectname => Ok(Object::Named(parse_objectname(inner)?)),
         Rule::nth => Ok(Object::Nth(parse_nth(inner)?)),
-        _ => Err(miette::miette!("Invalid object: {:?}", inner.as_rule())),
+        _ => Err(PikruError::Generic(format!(
+            "Invalid object: {:?}",
+            inner.as_rule()
+        ))),
     }
 }
 
-fn parse_objectname(pair: Pair<Rule>) -> Result<ObjectName, miette::Report> {
+fn parse_objectname(pair: Pair<Rule>) -> Result<ObjectName, PikruError> {
     // Grammar: objectname = { "this" ~ dot_name* | PLACENAME ~ dot_name* }
     // "this" is a keyword - may not be captured. PLACENAME should be captured.
     let pair_str = pair.as_str();
@@ -1383,7 +1418,7 @@ fn parse_objectname(pair: Pair<Rule>) -> Result<ObjectName, miette::Report> {
     Ok(ObjectName { base, path })
 }
 
-fn parse_nth(pair: Pair<Rule>) -> Result<Nth, miette::Report> {
+fn parse_nth(pair: Pair<Rule>) -> Result<Nth, PikruError> {
     let pair_str = pair.as_str();
     let mut inner = pair.into_inner().peekable();
 
@@ -1415,7 +1450,10 @@ fn parse_nth(pair: Pair<Rule>) -> Result<Nth, miette::Report> {
                     .unwrap_or(1);
                 Ok(Nth::Ordinal(num, false, None))
             } else {
-                Err(miette::miette!("Invalid nth with no children: {}", s))
+                Err(PikruError::Generic(format!(
+                    "Invalid nth with no children: {}",
+                    s
+                )))
             };
         }
     };
@@ -1458,17 +1496,17 @@ fn parse_nth(pair: Pair<Rule>) -> Result<Nth, miette::Report> {
                     Ok(Nth::Last(class))
                 }
                 "previous" => Ok(Nth::Previous),
-                _ => Err(miette::miette!(
+                _ => Err(PikruError::Generic(format!(
                     "Invalid nth: {} (rule: {:?})",
                     s,
                     first.as_rule()
-                )),
+                ))),
             }
         }
     }
 }
 
-fn parse_nth_class(pair: Pair<Rule>) -> Result<NthClass, miette::Report> {
+fn parse_nth_class(pair: Pair<Rule>) -> Result<NthClass, PikruError> {
     if pair.as_str() == "[" || pair.as_str() == "]" {
         return Ok(NthClass::Sublist);
     }
@@ -1484,7 +1522,7 @@ fn parse_nth_class(pair: Pair<Rule>) -> Result<NthClass, miette::Report> {
     Ok(NthClass::Sublist)
 }
 
-fn parse_edgepoint(pair: Pair<Rule>) -> Result<EdgePoint, miette::Report> {
+fn parse_edgepoint(pair: Pair<Rule>) -> Result<EdgePoint, PikruError> {
     match pair.as_str() {
         "north" | "n" => Ok(EdgePoint::North),
         "south" | "s" => Ok(EdgePoint::South),
@@ -1501,11 +1539,11 @@ fn parse_edgepoint(pair: Pair<Rule>) -> Result<EdgePoint, miette::Report> {
         "nw" => Ok(EdgePoint::NorthWest),
         "se" => Ok(EdgePoint::SouthEast),
         "sw" => Ok(EdgePoint::SouthWest),
-        s => Err(miette::miette!("Invalid edgepoint: {}", s)),
+        s => Err(PikruError::Generic(format!("Invalid edgepoint: {}", s))),
     }
 }
 
-fn parse_string(pair: Pair<Rule>) -> Result<String, miette::Report> {
+fn parse_string(pair: Pair<Rule>) -> Result<String, PikruError> {
     let s = pair.as_str();
     // Remove quotes and preserve backslash escape sequences
     // Note: C pikchr does NOT interpret \n, \t, etc. during parsing - it processes

--- a/src/render/eval.rs
+++ b/src/render/eval.rs
@@ -1,6 +1,7 @@
 //! Expression evaluation functions
 
 use crate::ast::*;
+use crate::errors::PikruError;
 use crate::types::{Angle, EvalValue, Length as Inches, OffsetIn, Point};
 
 use super::context::RenderContext;
@@ -74,7 +75,7 @@ fn get_nth_vertex(obj: &RenderedObject, nth: &Nth) -> PointIn {
     }
 }
 
-pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Report> {
+pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, PikruError> {
     match expr {
         Expr::Number(n) => {
             // cref: pik_expr (pikchr.c) - bare numbers are unitless scalars
@@ -82,7 +83,9 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
             // interpreted as inches. But in expressions like "2*dw", the 2 is a scalar
             // multiplier, so Scalar * Length = Length works correctly.
             if !n.is_finite() {
-                return Err(miette::miette!("Invalid numeric literal: not finite"));
+                return Err(PikruError::Generic(
+                    "Invalid numeric literal: not finite".to_string(),
+                ));
             }
             Ok(Value::Scalar(*n))
         }
@@ -99,18 +102,18 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                     .and_then(|s| s.strip_suffix(')'))
                 {
                     let parts: Vec<&str> = rgb.split(',').collect();
-                    if parts.len() == 3 {
-                        if let (Ok(r), Ok(g), Ok(b)) = (
+                    if parts.len() == 3
+                        && let (Ok(r), Ok(g), Ok(b)) = (
                             parts[0].trim().parse::<u32>(),
                             parts[1].trim().parse::<u32>(),
                             parts[2].trim().parse::<u32>(),
-                        ) {
-                            let color_val = (r << 16) | (g << 8) | b;
-                            return Ok(Value::from(EvalValue::Color(color_val)));
-                        }
+                        )
+                    {
+                        let color_val = (r << 16) | (g << 8) | b;
+                        return Ok(Value::from(EvalValue::Color(color_val)));
                     }
                 }
-                Err(miette::miette!("Undefined variable: {}", name))
+                Err(PikruError::Generic(format!("Undefined variable: {}", name)))
             }
         }
         Expr::BuiltinVar(b) => {
@@ -123,7 +126,7 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                 .get(key)
                 .copied()
                 .map(Value::from)
-                .ok_or_else(|| miette::miette!("Undefined builtin: {}", key))
+                .ok_or_else(|| PikruError::Generic(format!("Undefined builtin: {}", key)))
         }
         Expr::BinaryOp(lhs, op, rhs) => {
             let l = eval_expr(ctx, lhs)?;
@@ -140,7 +143,7 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                 (Len(a), Len(b), BinaryOp::Div) => a
                     .checked_div(b)
                     .map(|s| Scalar(s.raw()))
-                    .ok_or_else(|| miette::miette!("Division by zero"))?,
+                    .ok_or_else(|| PikruError::Generic("Division by zero".to_string()))?,
                 // Length + Scalar: treat scalar as length (C compatibility)
                 (Len(a), Scalar(b), BinaryOp::Add) => Len(a + Inches::inches(b)),
                 (Len(a), Scalar(b), BinaryOp::Sub) => Len(a - Inches::inches(b)),
@@ -149,7 +152,7 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                 // Length / Scalar = Length (typed op)
                 (Len(a), Scalar(b), BinaryOp::Div) => {
                     if b == 0.0 {
-                        return Err(miette::miette!("Division by zero"));
+                        return Err(PikruError::Generic("Division by zero".to_string()));
                     }
                     Len(a / b)
                 }
@@ -161,7 +164,7 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                 // Scalar / Length = Scalar (inverse scaling)
                 (Scalar(a), Len(b), BinaryOp::Div) => {
                     if b.raw() == 0.0 {
-                        return Err(miette::miette!("Division by zero"));
+                        return Err(PikruError::Generic("Division by zero".to_string()));
                     }
                     Scalar(a / b.raw())
                 }
@@ -171,13 +174,15 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                 (Scalar(a), Scalar(b), BinaryOp::Mul) => Scalar(a * b),
                 (Scalar(a), Scalar(b), BinaryOp::Div) => {
                     if b == 0.0 {
-                        return Err(miette::miette!("Division by zero"));
+                        return Err(PikruError::Generic("Division by zero".to_string()));
                     }
                     Scalar(a / b)
                 }
                 // Colors can't participate in mathematical operations
                 (Color(_), _, _) | (_, Color(_), _) => {
-                    return Err(miette::miette!("Cannot perform math operations on colors"));
+                    return Err(PikruError::Generic(
+                        "Cannot perform math operations on colors".to_string(),
+                    ));
                 }
             };
             // Validate result is finite (catches overflow to infinity)
@@ -191,7 +196,9 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                 (UnaryOp::Neg, Value::Scalar(s)) => Value::Scalar(-s),
                 (UnaryOp::Pos, Value::Scalar(s)) => Value::Scalar(s),
                 (_, Value::Color(_)) => {
-                    return Err(miette::miette!("Cannot perform unary operations on colors"));
+                    return Err(PikruError::Generic(
+                        "Cannot perform unary operations on colors".to_string(),
+                    ));
                 }
             })
         }
@@ -204,13 +211,21 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                 Function::Abs => match args[0] {
                     Len(l) => Len(l.abs()), // typed abs
                     Scalar(s) => Scalar(s.abs()),
-                    Color(_) => return Err(miette::miette!("Cannot take abs() of a color")),
+                    Color(_) => {
+                        return Err(PikruError::Generic(
+                            "Cannot take abs() of a color".to_string(),
+                        ));
+                    }
                 },
                 Function::Cos => {
                     let v = match args[0] {
                         Len(l) => l.raw(),
                         Scalar(s) => s,
-                        Color(_) => return Err(miette::miette!("Cannot take cos() of a color")),
+                        Color(_) => {
+                            return Err(PikruError::Generic(
+                                "Cannot take cos() of a color".to_string(),
+                            ));
+                        }
                     };
                     Scalar(v.to_radians().cos())
                 }
@@ -218,32 +233,56 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                     let v = match args[0] {
                         Len(l) => l.raw(),
                         Scalar(s) => s,
-                        Color(_) => return Err(miette::miette!("Cannot take sin() of a color")),
+                        Color(_) => {
+                            return Err(PikruError::Generic(
+                                "Cannot take sin() of a color".to_string(),
+                            ));
+                        }
                     };
                     Scalar(v.to_radians().sin())
                 }
                 Function::Int => match args[0] {
                     Len(l) => Len(Inches::inches(l.raw().trunc())),
                     Scalar(s) => Scalar(s.trunc()),
-                    Color(_) => return Err(miette::miette!("Cannot take int() of a color")),
+                    Color(_) => {
+                        return Err(PikruError::Generic(
+                            "Cannot take int() of a color".to_string(),
+                        ));
+                    }
                 },
                 Function::Sqrt => match args[0] {
-                    Len(l) if l.raw() < 0.0 => return Err(miette::miette!("sqrt of negative")),
+                    Len(l) if l.raw() < 0.0 => {
+                        return Err(PikruError::Generic("sqrt of negative".to_string()));
+                    }
                     Len(l) => Len(Inches::inches(l.raw().sqrt())),
-                    Scalar(s) if s < 0.0 => return Err(miette::miette!("sqrt of negative")),
+                    Scalar(s) if s < 0.0 => {
+                        return Err(PikruError::Generic("sqrt of negative".to_string()));
+                    }
                     Scalar(s) => Scalar(s.sqrt()),
-                    Color(_) => return Err(miette::miette!("Cannot take sqrt() of a color")),
+                    Color(_) => {
+                        return Err(PikruError::Generic(
+                            "Cannot take sqrt() of a color".to_string(),
+                        ));
+                    }
                 },
                 Function::Max => {
                     let a = match args[0] {
                         Len(l) => l.raw(),
                         Scalar(s) => s,
-                        Color(_) => return Err(miette::miette!("Cannot take max() of a color")),
+                        Color(_) => {
+                            return Err(PikruError::Generic(
+                                "Cannot take max() of a color".to_string(),
+                            ));
+                        }
                     };
                     let b = match args[1] {
                         Len(l) => l.raw(),
                         Scalar(s) => s,
-                        Color(_) => return Err(miette::miette!("Cannot take max() of a color")),
+                        Color(_) => {
+                            return Err(PikruError::Generic(
+                                "Cannot take max() of a color".to_string(),
+                            ));
+                        }
                     };
                     Scalar(a.max(b))
                 }
@@ -251,12 +290,20 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
                     let a = match args[0] {
                         Len(l) => l.raw(),
                         Scalar(s) => s,
-                        Color(_) => return Err(miette::miette!("Cannot take min() of a color")),
+                        Color(_) => {
+                            return Err(PikruError::Generic(
+                                "Cannot take min() of a color".to_string(),
+                            ));
+                        }
                     };
                     let b = match args[1] {
                         Len(l) => l.raw(),
                         Scalar(s) => s,
-                        Color(_) => return Err(miette::miette!("Cannot take min() of a color")),
+                        Color(_) => {
+                            return Err(PikruError::Generic(
+                                "Cannot take min() of a color".to_string(),
+                            ));
+                        }
                     };
                     Scalar(a.min(b))
                 }
@@ -272,8 +319,9 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
             Ok(Value::Len(dist))
         }
         Expr::ObjectProp(obj, prop) => {
-            let r = resolve_object(ctx, obj)
-                .ok_or_else(|| miette::miette!("Unknown object in property lookup"))?;
+            let r = resolve_object(ctx, obj).ok_or_else(|| {
+                PikruError::Generic("Unknown object in property lookup".to_string())
+            })?;
             let val = match prop {
                 NumProperty::Width => r.width(),
                 NumProperty::Height => r.height(),
@@ -286,15 +334,16 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
         }
         Expr::ObjectCoord(obj, coord) => {
             let r = resolve_object(ctx, obj)
-                .ok_or_else(|| miette::miette!("Unknown object in coord lookup"))?;
+                .ok_or_else(|| PikruError::Generic("Unknown object in coord lookup".to_string()))?;
             Ok(Value::Len(match coord {
                 Coord::X => r.center().x,
                 Coord::Y => r.center().y,
             }))
         }
         Expr::ObjectEdgeCoord(obj, edge, coord) => {
-            let r = resolve_object(ctx, obj)
-                .ok_or_else(|| miette::miette!("Unknown object in edge coord lookup"))?;
+            let r = resolve_object(ctx, obj).ok_or_else(|| {
+                PikruError::Generic("Unknown object in edge coord lookup".to_string())
+            })?;
             let pt = get_edge_point(r, edge);
             Ok(Value::Len(match coord {
                 Coord::X => pt.x,
@@ -302,38 +351,43 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, miette::Repo
             }))
         }
         Expr::VertexCoord(nth, obj, coord) => {
-            let r = resolve_object(ctx, obj)
-                .ok_or_else(|| miette::miette!("Unknown object in vertex coord lookup"))?;
+            let r = resolve_object(ctx, obj).ok_or_else(|| {
+                PikruError::Generic("Unknown object in vertex coord lookup".to_string())
+            })?;
             let target = get_nth_vertex(r, nth);
             Ok(Value::Len(match coord {
                 Coord::X => target.x,
                 Coord::Y => target.y,
             }))
         }
-        Expr::PlaceName(name) => Err(miette::miette!(
+        Expr::PlaceName(name) => Err(PikruError::Generic(format!(
             "Unsupported place name in expression: {}",
             name
+        ))),
+    }
+}
+
+pub fn eval_len(ctx: &RenderContext, expr: &Expr) -> Result<Inches, PikruError> {
+    match eval_expr(ctx, expr)? {
+        Value::Len(l) => Ok(l),
+        Value::Scalar(s) => Ok(Inches(s)), // treat scalar as inches for len contexts
+        Value::Color(_) => Err(PikruError::Generic(
+            "Cannot use a color as a length".to_string(),
         )),
     }
 }
 
-pub fn eval_len(ctx: &RenderContext, expr: &Expr) -> Result<Inches, miette::Report> {
-    match eval_expr(ctx, expr)? {
-        Value::Len(l) => Ok(l),
-        Value::Scalar(s) => Ok(Inches(s)), // treat scalar as inches for len contexts
-        Value::Color(_) => Err(miette::miette!("Cannot use a color as a length")),
-    }
-}
-
-pub fn eval_scalar(ctx: &RenderContext, expr: &Expr) -> Result<f64, miette::Report> {
+pub fn eval_scalar(ctx: &RenderContext, expr: &Expr) -> Result<f64, PikruError> {
     match eval_expr(ctx, expr)? {
         Value::Scalar(s) => Ok(s),
         Value::Len(l) => Ok(l.0),
-        Value::Color(_) => Err(miette::miette!("Cannot use a color as a scalar")),
+        Value::Color(_) => Err(PikruError::Generic(
+            "Cannot use a color as a scalar".to_string(),
+        )),
     }
 }
 
-pub fn eval_rvalue(ctx: &RenderContext, rvalue: &RValue) -> Result<EvalValue, miette::Report> {
+pub fn eval_rvalue(ctx: &RenderContext, rvalue: &RValue) -> Result<EvalValue, PikruError> {
     match rvalue {
         RValue::Expr(e) => {
             crate::log::debug!("eval_rvalue: RValue::Expr({:?})", e);
@@ -353,16 +407,16 @@ pub fn eval_rvalue(ctx: &RenderContext, rvalue: &RValue) -> Result<EvalValue, mi
                 .and_then(|s| s.strip_suffix(')'))
             {
                 let parts: Vec<&str> = rgb.split(',').collect();
-                if parts.len() == 3 {
-                    if let (Ok(r), Ok(g), Ok(b)) = (
+                if parts.len() == 3
+                    && let (Ok(r), Ok(g), Ok(b)) = (
                         parts[0].trim().parse::<u32>(),
                         parts[1].trim().parse::<u32>(),
                         parts[2].trim().parse::<u32>(),
-                    ) {
-                        let color_val = (r << 16) | (g << 8) | b;
-                        crate::log::debug!("eval_rvalue: returning Color({})", color_val);
-                        return Ok(EvalValue::Color(color_val));
-                    }
+                    )
+                {
+                    let color_val = (r << 16) | (g << 8) | b;
+                    crate::log::debug!("eval_rvalue: returning Color({})", color_val);
+                    return Ok(EvalValue::Color(color_val));
                 }
             }
             crate::log::debug!("eval_rvalue: failed to parse color, returning Scalar(0.0)");
@@ -371,7 +425,7 @@ pub fn eval_rvalue(ctx: &RenderContext, rvalue: &RValue) -> Result<EvalValue, mi
     }
 }
 
-pub fn eval_position(ctx: &RenderContext, pos: &Position) -> Result<PointIn, miette::Report> {
+pub fn eval_position(ctx: &RenderContext, pos: &Position) -> Result<PointIn, PikruError> {
     match pos {
         Position::Coords(x, y) => {
             let px = eval_len(ctx, x)?;
@@ -506,15 +560,15 @@ fn endpoint_object_from_place(ctx: &RenderContext, place: &Place) -> Option<Endp
             // C pikchr does NOT trigger implicit autochop (both endpoints present).
             // However, explicit `chop` attribute DOES work for dotted names.
             // We mark dotted names so the autochop logic can differentiate.
-            if let Object::Named(name) = obj {
-                if !name.path.is_empty() {
-                    // Object is inside a sublist (e.g., Ptr.A) - mark as dotted name
-                    crate::log::debug!(
-                        ?name,
-                        "endpoint_object_from_place: dotted name (explicit chop works, implicit autochop disabled)"
-                    );
-                    return resolve_object(ctx, obj).map(EndpointObject::from_rendered_dotted);
-                }
+            if let Object::Named(name) = obj
+                && !name.path.is_empty()
+            {
+                // Object is inside a sublist (e.g., Ptr.A) - mark as dotted name
+                crate::log::debug!(
+                    ?name,
+                    "endpoint_object_from_place: dotted name (explicit chop works, implicit autochop disabled)"
+                );
+                return resolve_object(ctx, obj).map(EndpointObject::from_rendered_dotted);
             }
             resolve_object(ctx, obj).map(EndpointObject::from_rendered)
         }
@@ -524,25 +578,24 @@ fn endpoint_object_from_place(ctx: &RenderContext, place: &Place) -> Option<Endp
     }
 }
 
-fn eval_place(ctx: &RenderContext, place: &Place) -> Result<PointIn, miette::Report> {
+fn eval_place(ctx: &RenderContext, place: &Place) -> Result<PointIn, PikruError> {
     match place {
         Place::Object(obj) => {
             if let Some(rendered) = resolve_object(ctx, obj) {
                 Ok(rendered.center())
             } else {
                 // Check if it's a named position (e.g., `OUT: 6.3in right of previous.e`)
-                if let Object::Named(name) = obj {
-                    if let ObjectNameBase::PlaceName(n) = &name.base {
-                        if let Some(pos) = ctx.get_named_position(n) {
-                            crate::log::debug!(
-                                name = %n,
-                                x = pos.x.raw(),
-                                y = pos.y.raw(),
-                                "eval_place: found named position"
-                            );
-                            return Ok(pos);
-                        }
-                    }
+                if let Object::Named(name) = obj
+                    && let ObjectNameBase::PlaceName(n) = &name.base
+                    && let Some(pos) = ctx.get_named_position(n)
+                {
+                    crate::log::debug!(
+                        name = %n,
+                        x = pos.x.raw(),
+                        y = pos.y.raw(),
+                        "eval_place: found named position"
+                    );
+                    return Ok(pos);
                 }
                 Ok(ctx.position)
             }
@@ -806,13 +859,13 @@ pub fn get_scalar(ctx: &RenderContext, name: &str, default: f64) -> f64 {
 }
 
 /// Validate that a Value is finite (not NaN or infinity from overflow)
-fn validate_value(v: Value) -> Result<Value, miette::Report> {
+fn validate_value(v: Value) -> Result<Value, PikruError> {
     match v {
-        Value::Len(l) if !l.is_finite() => Err(miette::miette!(
-            "Arithmetic overflow (result is infinite or NaN)"
+        Value::Len(l) if !l.is_finite() => Err(PikruError::Generic(
+            "Arithmetic overflow (result is infinite or NaN)".to_string(),
         )),
-        Value::Scalar(s) if !s.is_finite() => Err(miette::miette!(
-            "Arithmetic overflow (result is infinite or NaN)"
+        Value::Scalar(s) if !s.is_finite() => Err(PikruError::Generic(
+            "Arithmetic overflow (result is infinite or NaN)".to_string(),
         )),
         _ => Ok(v),
     }

--- a/src/render/geometry.rs
+++ b/src/render/geometry.rs
@@ -142,26 +142,22 @@ pub fn apply_auto_chop_simple_line(
         .unwrap_or(start);
 
     let mut new_start = start;
-    if should_chop_start {
-        if let Some(ref start_info) = obj.start_attachment {
-            // Chop against start object, toward the end object's center
-            if let Some(chopped) =
-                chop_against_endpoint(scaler, start_info, end_center_px, offset_x, max_y)
-            {
-                new_start = chopped;
-            }
+    if should_chop_start && let Some(ref start_info) = obj.start_attachment {
+        // Chop against start object, toward the end object's center
+        if let Some(chopped) =
+            chop_against_endpoint(scaler, start_info, end_center_px, offset_x, max_y)
+        {
+            new_start = chopped;
         }
     }
 
     let mut new_end = end;
-    if should_chop_end {
-        if let Some(ref end_info) = obj.end_attachment {
-            // Chop against end object, toward the start object's center
-            if let Some(chopped) =
-                chop_against_endpoint(scaler, end_info, start_center_px, offset_x, max_y)
-            {
-                new_end = chopped;
-            }
+    if should_chop_end && let Some(ref end_info) = obj.end_attachment {
+        // Chop against end object, toward the start object's center
+        if let Some(chopped) =
+            chop_against_endpoint(scaler, end_info, start_center_px, offset_x, max_y)
+        {
+            new_end = chopped;
         }
     }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -23,6 +23,7 @@ pub use shapes::Shape;
 pub use types::*;
 
 use crate::ast::*;
+use crate::errors::PikruError;
 use crate::types::{EvalValue, Length as Inches, OffsetIn, Point};
 use eval::{
     endpoint_object_from_position, eval_color, eval_expr, eval_len, eval_position, eval_rvalue,
@@ -173,7 +174,7 @@ fn monospace_text_length(text: &str) -> u32 {
 }
 
 /// Render a pikchr program to SVG with default options
-pub fn render(program: &Program) -> Result<String, miette::Report> {
+pub fn render(program: &Program) -> Result<String, PikruError> {
     render_with_options(program, &RenderOptions::default())
 }
 
@@ -181,7 +182,7 @@ pub fn render(program: &Program) -> Result<String, miette::Report> {
 pub fn render_with_options(
     program: &Program,
     options: &RenderOptions,
-) -> Result<String, miette::Report> {
+) -> Result<String, PikruError> {
     let mut ctx = RenderContext::new();
     let mut print_lines: Vec<String> = Vec::new();
 
@@ -221,7 +222,7 @@ fn render_statement(
     ctx: &mut RenderContext,
     stmt: &Statement,
     print_lines: &mut Vec<String>,
-) -> Result<(), miette::Report> {
+) -> Result<(), PikruError> {
     match stmt {
         Statement::Direction(dir) => {
             // cref: pik_set_direction (pikchr.c:5746)
@@ -410,7 +411,7 @@ fn render_statement(
         }
         Statement::Error(e) => {
             // Error statement produces an intentional error
-            return Err(miette::miette!("error: {}", e.message));
+            return Err(PikruError::Generic(format!("error: {}", e.message)));
         }
     }
     Ok(())
@@ -751,7 +752,7 @@ fn render_object_stmt(
     ctx: &mut RenderContext,
     obj_stmt: &ObjectStatement,
     name: Option<String>,
-) -> Result<RenderedObject, miette::Report> {
+) -> Result<RenderedObject, PikruError> {
     // Extract class name for shapes that have one
     let class_name: Option<ClassName> = match &obj_stmt.basetype {
         BaseType::Class(cn) => Some(*cn),
@@ -1618,15 +1619,16 @@ fn render_object_stmt(
                         class,
                         ClassName::Line | ClassName::Arrow | ClassName::Spline
                     );
-                    if source_is_line && current_is_line {
-                        if let Some(wpts) = source.waypoints() {
-                            // Store the waypoints; they'll be translated to start position later
-                            same_path_waypoints = Some(wpts.to_vec());
-                            crate::log::debug!(
-                                num_waypoints = wpts.len(),
-                                "same as: copied waypoints from source line"
-                            );
-                        }
+                    if source_is_line
+                        && current_is_line
+                        && let Some(wpts) = source.waypoints()
+                    {
+                        // Store the waypoints; they'll be translated to start position later
+                        same_path_waypoints = Some(wpts.to_vec());
+                        crate::log::debug!(
+                            num_waypoints = wpts.len(),
+                            "same as: copied waypoints from source line"
+                        );
                     }
 
                     // For non-line objects, copy width/height
@@ -2089,10 +2091,10 @@ fn render_object_stmt(
 
     // Save final pending then segment if there is one
     // cref: C pikchr saves the current path point when processing completes
-    if let Some(direction) = current_segment_direction {
-        if in_then_segment {
-            segments.push(Segment::Offset(current_segment_offset, direction));
-        }
+    if let Some(direction) = current_segment_direction
+        && in_then_segment
+    {
+        segments.push(Segment::Offset(current_segment_offset, direction));
     }
 
     // Calculate position based on object type
@@ -2540,15 +2542,15 @@ fn render_object_stmt(
     if !children.is_empty() {
         // Children were rendered in local coords starting at (0,0).
         // We need to translate them so their center aligns with the sublist's center.
-        if let Some(ref bounds) = sublist_bounds {
-            if !bounds.is_empty() {
-                // The children's center in local coords
-                let local_center = bounds.center();
-                // Offset from local center to final center
-                let offset = center - local_center;
-                for child in children.iter_mut() {
-                    child.translate(offset);
-                }
+        if let Some(ref bounds) = sublist_bounds
+            && !bounds.is_empty()
+        {
+            // The children's center in local coords
+            let local_center = bounds.center();
+            // Offset from local center to final center
+            let offset = center - local_center;
+            for child in children.iter_mut() {
+                child.translate(offset);
             }
         }
     }
@@ -2786,7 +2788,7 @@ fn render_object_stmt(
 fn render_sublist(
     parent_ctx: &RenderContext,
     statements: &[Statement],
-) -> Result<Vec<RenderedObject>, miette::Report> {
+) -> Result<Vec<RenderedObject>, PikruError> {
     // Local context: starts at (0,0) but inherits variables and direction
     let mut ctx = RenderContext::new();
     ctx.direction = parent_ctx.direction;

--- a/src/render/shapes.rs
+++ b/src/render/shapes.rs
@@ -1263,29 +1263,29 @@ impl Shape for LineShape {
             let mut draw_end = svg_points[svg_points.len() - 1];
 
             // cref: lineRender (pikchr.c:4271-4276) - larrow first, then rarrow
-            if self.style.arrow_start {
-                if let Some(arrowhead) = render_arrowhead_dom(
+            if self.style.arrow_start
+                && let Some(arrowhead) = render_arrowhead_dom(
                     draw_end,
                     draw_start,
                     &self.style,
                     arrow_len_px,
                     arrow_wid_px,
                     ctx.use_css_vars,
-                ) {
-                    nodes.push(SvgNode::Polygon(arrowhead));
-                }
+                )
+            {
+                nodes.push(SvgNode::Polygon(arrowhead));
             }
-            if self.style.arrow_end {
-                if let Some(arrowhead) = render_arrowhead_dom(
+            if self.style.arrow_end
+                && let Some(arrowhead) = render_arrowhead_dom(
                     draw_start,
                     draw_end,
                     &self.style,
                     arrow_len_px,
                     arrow_wid_px,
                     ctx.use_css_vars,
-                ) {
-                    nodes.push(SvgNode::Polygon(arrowhead));
-                }
+                )
+            {
+                nodes.push(SvgNode::Polygon(arrowhead));
             }
 
             if self.style.arrow_start {
@@ -1328,30 +1328,30 @@ impl Shape for LineShape {
         // cref: lineRender (pikchr.c:4271-4276) - larrow first, then rarrow
         // Render arrowheads before chopping endpoints
         if svg_points.len() >= 2 {
-            if self.style.arrow_start {
-                if let Some(arrowhead) = render_arrowhead_dom(
+            if self.style.arrow_start
+                && let Some(arrowhead) = render_arrowhead_dom(
                     svg_points[1],
                     svg_points[0],
                     &self.style,
                     arrow_len_px,
                     arrow_wid_px,
                     ctx.use_css_vars,
-                ) {
-                    nodes.push(SvgNode::Polygon(arrowhead));
-                }
+                )
+            {
+                nodes.push(SvgNode::Polygon(arrowhead));
             }
             let n = svg_points.len();
-            if self.style.arrow_end {
-                if let Some(arrowhead) = render_arrowhead_dom(
+            if self.style.arrow_end
+                && let Some(arrowhead) = render_arrowhead_dom(
                     svg_points[n - 2],
                     svg_points[n - 1],
                     &self.style,
                     arrow_len_px,
                     arrow_wid_px,
                     ctx.use_css_vars,
-                ) {
-                    nodes.push(SvgNode::Polygon(arrowhead));
-                }
+                )
+            {
+                nodes.push(SvgNode::Polygon(arrowhead));
             }
             // Chop endpoints for arrow space
             if self.style.arrow_start {

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -2,6 +2,7 @@
 
 use super::shapes::{Shape, ShapeRenderContext, svg_style_from_entries};
 use super::{TextVSlot, compute_text_vslots};
+use crate::errors::PikruError;
 use crate::types::{Length as Inches, Scaler};
 use facet_svg::facet_xml::SerializeOptions;
 use facet_svg::{Circle as SvgCircle, Points, Polygon, Style, Svg, SvgNode, Text, facet_xml};
@@ -254,7 +255,7 @@ fn generate_color_css() -> Style {
 pub fn generate_svg(
     ctx: &RenderContext,
     options: &super::RenderOptions,
-) -> Result<String, miette::Report> {
+) -> Result<String, PikruError> {
     let margin_base = get_length(ctx, "margin", defaults::MARGIN);
     let left_margin = get_length(ctx, "leftmargin", 0.0);
     let right_margin = get_length(ctx, "rightmargin", 0.0);
@@ -271,7 +272,7 @@ pub fn generate_svg(
     // Scale only affects the display width/height attributes
     let r_scale = 144.0;
     let scaler = Scaler::try_new(r_scale)
-        .map_err(|e| miette::miette!("invalid scale value {}: {}", r_scale, e))?;
+        .map_err(|e| PikruError::Generic(format!("invalid scale value {}: {}", r_scale, e)))?;
     let arrow_ht = Inches(get_length(ctx, "arrowht", 0.08));
     let arrow_wid = Inches(get_length(ctx, "arrowwid", 0.06));
     let dashwid = Inches(get_length(ctx, "dashwid", 0.05));
@@ -715,11 +716,11 @@ pub fn generate_svg(
 
         // Render debug labels for objects with explicit names
         for obj in sorted_objects.iter() {
-            if let Some(ref name) = obj.name {
-                if obj.name_is_explicit {
-                    let center = obj.center().to_svg(&scaler, offset_x, max_y);
-                    render_debug_label(name, center);
-                }
+            if let Some(ref name) = obj.name
+                && obj.name_is_explicit
+            {
+                let center = obj.center().to_svg(&scaler, offset_x, max_y);
+                render_debug_label(name, center);
             }
         }
 
@@ -745,7 +746,7 @@ pub fn generate_svg(
         ..Default::default()
     };
     facet_xml::to_string_with_options(&svg, &options_ser)
-        .map_err(|e| miette::miette!("XML serialization error: {}", e))
+        .map_err(|e| PikruError::Generic(format!("XML serialization error: {}", e)))
 }
 
 /// Render an arrowhead polygon at the end of a line

--- a/src/render/types.rs
+++ b/src/render/types.rs
@@ -1,6 +1,7 @@
 //! Core types for pikchr rendering
 
 use crate::ast::TextAttr;
+use crate::errors::PikruError;
 use crate::types::{BoxIn, EvalValue, Length as Inches, OffsetIn, Point, PtIn, UnitVec};
 
 use super::defaults;
@@ -16,20 +17,28 @@ pub enum Value {
 
 impl Value {
     #[allow(dead_code)]
-    pub fn as_len(self) -> Result<Inches, miette::Report> {
+    pub fn as_len(self) -> Result<Inches, PikruError> {
         match self {
             Value::Len(l) => Ok(l),
-            Value::Scalar(_) => Err(miette::miette!("Expected length value, got scalar")),
-            Value::Color(_) => Err(miette::miette!("Expected length value, got color")),
+            Value::Scalar(_) => Err(PikruError::Generic(
+                "Expected length value, got scalar".to_string(),
+            )),
+            Value::Color(_) => Err(PikruError::Generic(
+                "Expected length value, got color".to_string(),
+            )),
         }
     }
 
     #[allow(dead_code)]
-    pub fn as_scalar(self) -> Result<f64, miette::Report> {
+    pub fn as_scalar(self) -> Result<f64, PikruError> {
         match self {
             Value::Scalar(s) => Ok(s),
-            Value::Len(_) => Err(miette::miette!("Expected scalar value, got length")),
-            Value::Color(_) => Err(miette::miette!("Expected scalar value, got color")),
+            Value::Len(_) => Err(PikruError::Generic(
+                "Expected scalar value, got length".to_string(),
+            )),
+            Value::Color(_) => Err(PikruError::Generic(
+                "Expected scalar value, got color".to_string(),
+            )),
         }
     }
 }
@@ -151,7 +160,7 @@ impl PositionedText {
             scale *= 0.8;
         }
         if self.xtra {
-            scale *= scale;  // Square the scale for double big/small
+            scale *= scale; // Square the scale for double big/small
         }
         scale
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,6 @@ use std::fmt;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use glam::DVec2;
-use miette::SourceSpan;
 
 // ==================== Source Tracking ====================
 
@@ -60,9 +59,9 @@ impl Span {
     }
 }
 
-impl From<Span> for SourceSpan {
+impl From<Span> for std::ops::Range<usize> {
     fn from(s: Span) -> Self {
-        SourceSpan::new(s.start.into(), s.len())
+        s.start..s.end
     }
 }
 

--- a/tests/pikchr_tests.rs
+++ b/tests/pikchr_tests.rs
@@ -25,12 +25,6 @@ const DEBUG_SVG_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/debug-svg");
 fn test_pikchr_file(path: &Utf8Path) -> datatest_stable::Result<()> {
     init_tracing();
 
-    // Install miette fancy GraphicalReporter for better error display
-    miette::set_hook(Box::new(
-        |_| Box::new(miette::GraphicalReportHandler::new()),
-    ))
-    .ok();
-
     let source = std::fs::read_to_string(path)?;
 
     // Get expected output from C implementation

--- a/tests/test32_debug.rs
+++ b/tests/test32_debug.rs
@@ -77,10 +77,10 @@ fn extract_style_prop(line: &str, prop: &str) -> Option<String> {
     }
 
     // Also try fill="X" attribute format
-    if prop == "fill" {
-        if let Some(fill) = extract_attr(line, "fill") {
-            return Some(fill);
-        }
+    if prop == "fill"
+        && let Some(fill) = extract_attr(line, "fill")
+    {
+        return Some(fill);
     }
 
     None


### PR DESCRIPTION
## Summary

This PR replaces miette with ariadne (0.6) for diagnostic error reporting. The change simplifies the error handling API by returning formatted error strings instead of miette Report objects, making the library easier to integrate without forcing consumers to depend on miette.

## Changes

- **Dependencies**: Replace `miette 7.6.0` with `ariadne 0.6`, remove unused `pest_ascii_tree`
- **Error types**: Remove `Diagnostic` trait annotations, use custom `Span` type instead of miette's `SourceSpan`
- **Error formatting**: Implement `PikruError::to_report()` method that generates ariadne Reports with proper source context
- **Public API**: Change return types from `miette::Report` to `String` in `pikchr()` and `pikchr_with_options()`
- **Error propagation**: Update all error handling throughout the codebase to use the new error formatting approach
- **Code quality**: Fix all clippy warnings triggered by the refactoring

## Benefits

- **Lighter dependencies**: ariadne has a smaller dependency footprint compared to miette
- **Simpler API**: Returning strings is more straightforward for library consumers
- **Better control**: Custom error formatting logic gives us more flexibility
- **Cleaner integration**: Users don't need to depend on miette to use pikru

## Testing

All existing tests pass with the new error handling implementation.