### PR TITLE
Prepare pikru 2.0.0-rc.0

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - bearcove-ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Tests (Linux)
     runs-on: bearcove-ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     name: Tests (Linux)
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     name: Build comparison page
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: bearcove-ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
 
@@ -47,7 +47,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build comparison page
     runs-on: bearcove-ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -40,7 +40,7 @@ jobs:
           echo "pikru.bearcove.eu" > _site/CNAME
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     name: Deploy to GitHub Pages
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-plz-release:
     name: Release-plz release
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     environment: release
     permissions:
       contents: write
@@ -34,7 +34,7 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,8 +22,37 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Get crates.io token via OIDC
-        uses: rust-lang/crates-io-auth-action@v1
         id: crates-io-auth
+        shell: bash
+        env:
+          REGISTRY_URL: https://crates.io
+        run: |
+          set -euo pipefail
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::Please ensure the 'id-token' permission is set to 'write' in your workflow."
+            exit 1
+          fi
+
+          oidc_url="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=crates.io"
+          jwt="$(curl -fsSL -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${oidc_url}" | jq -r '.value')"
+          if [ -z "${jwt}" ] || [ "${jwt}" = "null" ]; then
+            echo "::error::Failed to retrieve GitHub Actions OIDC token"
+            exit 1
+          fi
+
+          token="$(jq -n --arg jwt "${jwt}" '{jwt: $jwt}' \
+            | curl -fsSL -X POST "${REGISTRY_URL}/api/v1/trusted_publishing/tokens" \
+                -H "Content-Type: application/json" \
+                -H "User-Agent: crates-io-auth-shell/1" \
+                --data @- \
+            | jq -r '.token')"
+          if [ -z "${token}" ] || [ "${token}" = "null" ]; then
+            echo "::error::Failed to retrieve crates.io token"
+            exit 1
+          fi
+
+          echo "::add-mask::${token}"
+          echo "token=${token}" >> "${GITHUB_OUTPUT}"
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
@@ -31,6 +60,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+      - name: Revoke crates.io token
+        if: always() && steps.crates-io-auth.outputs.token != ''
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+          REGISTRY_URL: https://crates.io
+        run: |
+          set -euo pipefail
+          curl -fsSL -X DELETE "${REGISTRY_URL}/api/v1/trusted_publishing/tokens" \
+            -H "Authorization: Bearer ${CARGO_REGISTRY_TOKEN}" \
+            -H "User-Agent: crates-io-auth-shell/1" \
+            --output /dev/null
 
   release-plz-pr:
     name: Release-plz PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa36099ca72f6fb53a63284034ecc747901103cc9ff2c37a3395056ff7bbae12"
+checksum = "b8d43d3564e06baf09ca8ab87072e49e603046af471f1ed68cbeb1ad3ec8fba2"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6691a60d328fa343c3bc34bb2dd2778f402b98aa774d52829a3d0572bcb98815"
+checksum = "a088a24ab676d6a7ed5ae3a7982a2092cc29684fe4e97b3827d5e239c76d9e79"
 dependencies = [
  "autocfg",
  "const-fnv1a-hash",
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "facet-dessert"
-version = "0.46.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4505ec8ef086d776fd99b86fb17e3d1c711188d27aa72845e64a30146226e3b"
+checksum = "93bcd8bfe96797c30bb5cbc7af19854bc793bcc29e884f3caea55ab4d0a76cf2"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "facet-dom"
-version = "0.46.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad3bd4bd603996bd095e75d08c0da6c70bc5a394bdcd5d8f689374683eec656"
+checksum = "8276a53156eed151697d04757835418513133d3d8e499b7e1951bc348a357c43"
 dependencies = [
  "facet-core",
  "facet-dessert",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "facet-format"
-version = "0.47.1"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2353807588cc4057a5e31bf459e7304ea84729ad77080e267928b1e09d36235"
+checksum = "bd9f89149e4d373016b1e9f263ce5f9e2171a432163badc3353cfbe3c8a5960f"
 dependencies = [
  "facet-core",
  "facet-dessert",
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "facet-json"
-version = "0.46.1"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fbb1d8aa586b5e6b189575d1eda196cd3014347aff36be8dd097401024fe6d"
+checksum = "e4a49a07dd025d269cf0f5b63679d08d2d9ddd080a578bbe3ec58e414ede1bd5"
 dependencies = [
  "facet",
  "facet-core",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671db275c95fe788e8c488e72221f55b78863dec510a48131b4517ba398f716a"
+checksum = "1a85e100b892473cef064ca8f3443af4c8eb78b8609eb3224eba8df679caf690"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -821,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f893ca809a6b5a1caffa3ebf9e88c7720793cde82a6b809b1e65f19b095ed2be"
+checksum = "87b2552407f6f584187a808bd4fbb56f002cc5451454294898276881c232d07a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,18 +832,18 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f8e1bfcea82611508c06b670ec34e7957827fefc02a0982eee2e75002ee05d"
+checksum = "b77f92b6fe3ae6d45544e50351a9a54f7190240220b283916cbcca20a849812b"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7517702043f5656a6ee7de64bf8b26a549dbbfe983f592be29bead7ff380d798"
+checksum = "cd1f0535febaea47d61f5386a6e0ab3249a5aaf813ae67e25bf285e97c481e30"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -855,18 +855,18 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7ec0955c6ed58229b136c1c8c5b9d9c93d7af4317b8f7a570bda726243c626"
+checksum = "4f0aeceb55a22d6ddb1d9d2af4a6223114ce6869821c0ae1091a3c955d1492a7"
 dependencies = [
  "facet-core",
 ]
 
 [[package]]
 name = "facet-pretty"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ecfa1b68303586aa84e8e68324877f657ce21bbda382f14a2d37277b514a710"
+checksum = "c2522ca631c6c71803ecc836d70d0def6db0eb9358bcc39fdbe5ffd44c914e2e"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304dd81b64f2f759735e9044c6cb2c8b9e5ad7d004bdf1b27dd7b2f2285c0e3e"
+checksum = "8287a68023eec4152a4d4cb88814e10d38ff6f116cbb70acb4eb58a304f624c6"
 dependencies = [
  "facet-core",
  "facet-path",
@@ -889,15 +889,15 @@ dependencies = [
 
 [[package]]
 name = "facet-singularize"
-version = "0.46.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa13541c3bdca7da541e626369d6a9626429067188cf1074a2ea282ffdcc301"
+checksum = "e621f8014a6cdfd8c9bf30b9102bb8746050a9c5de2cd98096d3eb69503490a3"
 
 [[package]]
 name = "facet-solver"
-version = "0.46.3"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16981fb80d2946389bc2dd3789e53c6f5cf1be3f25186f66f8582f748a03adf0"
+checksum = "f1d5bfeaa1e0dcbdfccf86b6f64e258b4d2db839b1573f0bbff8ee27a45a9fbc"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "facet-svg"
-version = "0.46.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a849508c83c55916fbf1e9f569f6f5ee523cb564d068a7499966038d34eb39"
+checksum = "43a57ff052ba6a7286d5c2cd67fb6e56ea98bbb63f716561aa95234b4f42908f"
 dependencies = [
  "facet",
  "facet-xml",
@@ -916,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "facet-xml"
-version = "0.46.0"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc566de3d117c51747b14e0ed6744d2b595bb8b06a374ea596a723a5b9445e86"
+checksum = "cb3208e3ab2d4c0c3beccf3d01ea0deb9a74225ff9ebd61c33f2eed432ac5400"
 dependencies = [
  "facet",
  "facet-core",
@@ -1847,7 +1847,7 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pikru"
-version = "1.2.1"
+version = "2.0.0-rc.0"
 dependencies = [
  "ariadne",
  "camino",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "pikru-compare"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "camino",
  "facet-svg",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "pikru-mcp"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "rediff"
-version = "0.46.1"
+version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ef0722279c417df747be3a3f3a1566619d3cd51fb1c3afe9d89a839d1a4b7f"
+checksum = "92b819e6eefb3c092c0019d6ef55d7a203c468460d18aeada437c238ffb71e03"
 dependencies = [
  "confusables",
  "facet",
@@ -2151,6 +2151,7 @@ dependencies = [
  "indextree",
  "owo-colors",
  "palette",
+ "terminal-colorsaurus",
  "unicode-width",
 ]
 
@@ -2654,6 +2655,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal-colorsaurus"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46bb5364467da040298c573c8a95dbf9a512efc039630409a03126e3703e90"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio",
+ "terminal-trx",
+ "windows-sys 0.61.2",
+ "xterm-color",
+]
+
+[[package]]
 name = "terminal-light"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,6 +2679,17 @@ dependencies = [
  "crossterm",
  "thiserror 1.0.69",
  "xterm-query",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3f27d9a8a177e57545481faec87acb45c6e854ed1e5a3658ad186c106f38ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3285,13 +3312,19 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xtask"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "camino",
  "pikru",
  "pikru-compare",
  "rayon",
 ]
+
+[[package]]
+name = "xterm-color"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
 
 [[package]]
 name = "xterm-query"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = ["xtask", "crates/pikru-mcp", "crates/pikru-compare"]
 
 [package]
 name = "pikru"
-version = "1.2.1"
+version = "2.0.0-rc.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.90"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 description = "A pure Rust implementation of pikchr, a PIC-like diagram markup language that generates SVG"
 license = "MIT OR Apache-2.0"
@@ -36,7 +36,7 @@ ariadne = "0.6"
 pest = "2.8.4"
 pest_derive = "2.8.4"
 # SVG DOM generation and XML serialization
-facet-svg = { version = "0.46" }
+facet-svg = { version = "0.50.0-rc.0" }
 # Debug logging (only emits when RUST_LOG is set) - optional
 tracing = { version = "0.1.43", optional = true }
 # Derive macro for custom error types

--- a/crates/pikru-compare/Cargo.toml
+++ b/crates/pikru-compare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pikru-compare"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 edition = "2024"
 publish = false
 
@@ -10,8 +10,8 @@ publish = false
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet-svg = { version = "0.46" }
-rediff = { version = "0.46" }
+facet-svg = { version = "0.50.0-rc.0" }
+rediff = { version = "0.50.0-rc.0" }
 camino = "1.2.1"
 
 # Visual comparison

--- a/crates/pikru-mcp/Cargo.toml
+++ b/crates/pikru-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pikru-mcp"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 edition = "2024"
 publish = false
 
@@ -22,8 +22,8 @@ anyhow = "1"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-facet = "0.46"
-facet-json = "0.46"
+facet = "0.50.0-rc.0"
+facet-json = "0.50.0-rc.0"
 
 # Image processing
 image = "0.25"

--- a/examples/css_vars.rs
+++ b/examples/css_vars.rs
@@ -1,4 +1,4 @@
-use pikru::render::{render_with_options, RenderOptions};
+use pikru::render::{RenderOptions, render_with_options};
 
 fn main() {
     let source = r#"

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -1,4 +1,4 @@
-fn main() { 
+fn main() {
     let source = std::fs::read_to_string(std::env::args().nth(1).unwrap()).unwrap();
     let result = pikru::pikchr(&source).unwrap();
     println!("{}", result);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,8 +3,8 @@
 use crate::ast::*;
 use crate::errors::PikruError;
 use crate::{PikchrParser, Rule};
-use pest::iterators::Pair;
 use pest::Parser;
+use pest::iterators::Pair;
 
 /// Parse pikchr source into AST
 pub fn parse(source: &str) -> Result<Program, PikruError> {
@@ -522,7 +522,7 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute, PikruError> {
             match s {
                 "go" => {
                     inner.next(); // skip "go"
-                                  // After "go", check what follows
+                    // After "go", check what follows
                     if let Some(next) = inner.peek() {
                         if next.as_rule() == Rule::direction {
                             parse_direction_attribute(&mut inner, &pair_str)
@@ -593,7 +593,7 @@ fn parse_attribute(pair: Pair<Rule>) -> Result<Attribute, PikruError> {
                 }
                 "same" => {
                     inner.next(); // skip "same"
-                                  // Skip "as" if present
+                    // Skip "as" if present
                     if inner.peek().map(|p| p.as_str() == "as").unwrap_or(false) {
                         inner.next();
                     }
@@ -1089,7 +1089,7 @@ fn parse_primary(pair: Pair<Rule>) -> Result<Expr, PikruError> {
                                 return Err(PikruError::Generic(format!(
                                     "Invalid numproperty: {}",
                                     prop_pair.as_str()
-                                )))
+                                )));
                             }
                         };
                         Ok(Expr::ObjectProp(obj, prop_ref))

--- a/src/render/eval.rs
+++ b/src/render/eval.rs
@@ -336,12 +336,8 @@ pub fn eval_expr(ctx: &RenderContext, expr: &Expr) -> Result<Value, PikruError> 
                 }
                 PropertyRef::Dash(prop) => {
                     let val = match prop {
-                        DashProperty::Dashed => {
-                            r.style().dashed.unwrap_or(Inches::ZERO)
-                        }
-                        DashProperty::Dotted => {
-                            r.style().dotted.unwrap_or(Inches::ZERO)
-                        }
+                        DashProperty::Dashed => r.style().dashed.unwrap_or(Inches::ZERO),
+                        DashProperty::Dotted => r.style().dotted.unwrap_or(Inches::ZERO),
                     };
                     Ok(Value::Len(val))
                 }
@@ -732,7 +728,10 @@ fn resolve_nth<'a>(ctx: &'a RenderContext, nth: &Nth) -> Option<&'a RenderedObje
 }
 
 /// Resolve an nth reference within a container's children
-fn resolve_nth_in_children<'a>(children: &'a [RenderedObject], nth: &Nth) -> Option<&'a RenderedObject> {
+fn resolve_nth_in_children<'a>(
+    children: &'a [RenderedObject],
+    nth: &Nth,
+) -> Option<&'a RenderedObject> {
     match nth {
         Nth::First(class) | Nth::Last(class) | Nth::Previous(class) => {
             let oc = class.as_ref().and_then(nth_class_to_class_name);

--- a/tests/pikchr_tests.rs
+++ b/tests/pikchr_tests.rs
@@ -1,5 +1,5 @@
 use camino::Utf8Path;
-use pikru_compare::{compare_outputs, run_c_pikchr, write_debug_svgs, CompareResult};
+use pikru_compare::{CompareResult, compare_outputs, run_c_pikchr, write_debug_svgs};
 use std::sync::Once;
 
 static INIT_TRACING: Once = Once::new();

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "1.2.0"
+version = "2.0.0-rc.0"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## Summary

- move Pikru Linux CI/pages/release workflows onto `bearcove-ubuntu-24.04` and add actionlint coverage
- update workflow actions to Node 24-safe refs and keep release publishing enabled through release-plz
- prepare `pikru`, `pikru-compare`, `pikru-mcp`, and `xtask` for `2.0.0-rc.0`
- bump Facet-family dependencies to `0.50.0-rc.0` (`facet-svg`, `facet`, `facet-json`) plus `rediff` to `0.50.0-rc.0`
- align `pikru` MSRV with the new Facet stack at Rust `1.90`
- include rustfmt cleanup surfaced by `cargo fmt --check`

## Action runtime audit

- `actions/checkout@v6`: `node24`
- `Swatinem/rust-cache@v2`: `node24`
- `actions/deploy-pages@v5`: `node24`
- `actions/upload-pages-artifact@v5`: composite; nested `actions/upload-artifact@v7.0.0` is `node24`
- `dtolnay/rust-toolchain@stable`: composite/shell
- `release-plz/action@v0.5`: composite/shell; nested `taiki-e/install-action`, `cargo-binstall`, and `release-plz/git-config` are composite/shell

## Verification

- `actionlint`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features --all-targets`
- `cargo clippy --workspace --all-targets --all-features --message-format=short -- -D warnings`
- `cc -O0 -g -Wall -Wextra -DPIKCHR_SHELL vendor/pikchr-c/pikchr.c -o vendor/pikchr-c/pikchr -lm`
- `cargo nextest list --workspace --all-features`
- `cargo nextest run --workspace --all-features` (213 passed)
- `./ci.sh`
- `cargo package --allow-dirty`
- push hook: cargo-shear, clippy, docs, build tests, run tests
